### PR TITLE
Vector Tile Creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["ingalls <ingalls@protonmail.com>"]
 [dependencies]
 rand = "0.4"
 tempdir = "0.3"
+postgis = "0.5.0"
+protobuf = "^1.4"
 base64 = "~0.9.0"
 rocket = "0.3.6"
 rocket_codegen = "0.3.6"

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Path: src/mvt/ contains code licensed under:
+
+MIT License
+
+Copyright (c) 2016 Pirmin Kalberer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/delta/mod.rs
+++ b/src/delta/mod.rs
@@ -1,8 +1,7 @@
-extern crate r2d2;
-extern crate r2d2_postgres;
 extern crate geojson;
-extern crate postgres;
 extern crate serde_json;
+
+use postgres;
 
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 #![feature(underscore_lifetimes)]
 extern crate clap;
 #[macro_use] extern crate serde_json;
+extern crate r2d2;
+extern crate r2d2_postgres;
+extern crate postgres;
+extern crate postgis;
+extern crate protobuf;
 
 pub mod delta;
+pub mod mvt;
 pub mod feature;
 pub mod bounds;
 pub mod xml;

--- a/src/mvt/builder.rs
+++ b/src/mvt/builder.rs
@@ -1,0 +1,152 @@
+use mvt::geom_encoder::{encode_geometry, encode_geometry_type};
+use mvt::geom::Geometry;
+use mvt::grid;
+use mvt::proto;
+use std::borrow::Cow;
+
+#[derive(Debug)]
+pub struct Tile<'a> {
+    bbox: &'a grid::Extent,
+    layers: Vec<Layer<'a>>,
+}
+
+impl<'a> Tile<'a> {
+    pub fn new<'b: 'a>(bbox: &'b grid::Extent) -> Tile<'a> {
+        Tile {
+            bbox: bbox,
+            layers: Vec::new(),
+        }
+    }
+
+    pub fn add_layer<'b: 'a>(&mut self, layer: Layer<'b>) {
+        self.layers.push(layer);
+    }
+
+    pub fn layers(&self) -> &[Layer<'a>] {
+        self.layers.as_slice()
+    }
+
+    pub fn encode(self, grid: &grid::Grid) -> proto::Tile {
+        let mut vec_tile = proto::Tile::new();
+        for layer in self.layers.into_iter() {
+            let mut vec_layer = proto::Tile_Layer::new();
+            vec_layer.set_version(2);
+            vec_layer.set_name(String::from(layer.name));
+            vec_layer.set_extent(4096);
+            for feature in layer.features.into_iter() {
+                let mut vec_feature = proto::Tile_Feature::new();
+                for property in feature.props.into_iter() {
+                    let mut vec_value = proto::Tile_Value::new();
+                    match property.value {
+                        Value::String(ref v) => vec_value.set_string_value(v.clone()),
+                        Value::F32(v) => vec_value.set_float_value(v),
+                        Value::F64(v) => vec_value.set_double_value(v),
+                        Value::I64(v) => vec_value.set_int_value(v),
+                        Value::U64(v) => vec_value.set_uint_value(v),
+                        Value::Bool(v) => vec_value.set_bool_value(v),
+                    }
+                    let key = match vec_layer.get_keys().iter().position(|k| *k == property.key) {
+                        None => {
+                            vec_layer.mut_keys().push(String::from(property.key));
+                            vec_layer.get_keys().len() - 1
+                        }
+                        Some(idx) => idx,
+                    };
+                    vec_feature.mut_tags().push(key as u32);
+                    let value = match vec_layer.get_values().iter().position(|v| *v == vec_value) {
+                        None => {
+                            vec_layer.mut_values().push(vec_value);
+                            vec_layer.get_values().len() - 1
+                        }
+                        Some(idx) => idx,
+                    };
+                    vec_feature.mut_tags().push(value as u32);
+                }
+                vec_feature.set_field_type(encode_geometry_type(&feature.geom));
+                vec_feature.set_geometry(encode_geometry(self.bbox, 4096, grid.reverse_y, feature.geom).vec());
+                vec_layer.mut_features().push(vec_feature);
+            }
+            vec_tile.mut_layers().push(vec_layer);
+        }
+        vec_tile
+    }
+}
+
+#[derive(Debug)]
+pub struct Layer<'a> {
+    name: Cow<'a, str>,
+    features: Vec<Feature<'a>>,
+}
+
+impl<'a> Layer<'a> {
+    pub fn new<S>(name: S) -> Layer<'a>
+        where S: Into<Cow<'a, str>>
+    {
+        Layer {
+            name: name.into(),
+            features: Vec::new(),
+        }
+    }
+
+    pub fn add_feature<'b: 'a>(&mut self, feature: Feature<'b>) {
+        self.features.push(feature);
+    }
+
+    pub fn features(&self) -> &[Feature<'a>] {
+        self.features.as_slice()
+    }
+}
+
+#[derive(Debug)]
+pub struct Property<'a> {
+    pub key: Cow<'a, str>,
+    pub value: Value,
+}
+
+#[derive(Debug)]
+pub struct Feature<'a> {
+    id: Option<u64>,
+    geom: Geometry,
+    props: Vec<Property<'a>>,
+}
+
+impl<'a> Feature<'a> {
+    pub fn new(geom: Geometry) -> Feature<'a> {
+        Feature {
+            id: None,
+            geom: geom,
+            props: Vec::new(),
+        }
+    }
+
+    pub fn set_id(&mut self, id: u64) {
+        self.id = Some(id);
+    }
+
+    pub fn add_property<S>(&mut self, key: S, value: Value)
+        where S: Into<Cow<'a, str>>
+    {
+        self.props.push(Property {
+            key: key.into(),
+            value: value,
+        })
+    }
+
+    pub fn geometry(&self) -> &Geometry {
+        &self.geom
+    }
+
+    pub fn properties(&self) -> &[Property] {
+        self.props.as_slice()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Value {
+    String(String),
+    F32(f32),
+    F64(f64),
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+}

--- a/src/mvt/builder_test.rs
+++ b/src/mvt/builder_test.rs
@@ -1,0 +1,199 @@
+use builder::{Tile, Layer, Feature, Value};
+use geom::{Geometry, Point};
+use grid::{Grid, Extent};
+use postgis::ewkb;
+
+#[test]
+fn test_build_tile() {
+    let bbox = Extent {
+        minx: 958826.08,
+        miny: 5987771.04,
+        maxx: 978393.96,
+        maxy: 6007338.92,
+    };
+    let mut tile = Tile::new(&bbox);
+    let mut layer = Layer::new("points");
+    let geom: Geometry = ewkb::GeometryT::Point(Point::new(960000.0, 6002729.0, Some(3857)));
+    let mut feature = Feature::new(geom);
+    feature.add_property("hello", Value::String(String::from("world")));
+    feature.add_property("h", Value::String(String::from("world")));
+    feature.add_property("count", Value::F64(1.23));
+    layer.add_feature(feature);
+
+    let geom: Geometry = ewkb::GeometryT::Point(Point::new(960000.0, 6002729.0, Some(3857)));
+    let mut feature = Feature::new(geom);
+    feature.add_property("hello", Value::String(String::from("again")));
+    feature.add_property("count", Value::I64(2));
+    layer.add_feature(feature);
+
+    tile.add_layer(layer);
+
+    // Encode the tile as protobuf structs
+    let grid = Grid::wgs84();
+    let data = tile.encode(&grid);
+    println!("{:#?}", data);
+    assert_eq!(TILE_EXAMPLE, &*format!("{:#?}", data));
+}
+
+const TILE_EXAMPLE: &'static str = r#"Tile {
+    layers: [
+        Tile_Layer {
+            version: Some(
+                2
+            ),
+            name: Some("points"),
+            features: [
+                Tile_Feature {
+                    id: None,
+                    tags: [
+                        0,
+                        0,
+                        1,
+                        0,
+                        2,
+                        1
+                    ],
+                    field_type: Some(
+                        POINT
+                    ),
+                    geometry: [
+                        9,
+                        490,
+                        6262
+                    ],
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                },
+                Tile_Feature {
+                    id: None,
+                    tags: [
+                        0,
+                        2,
+                        2,
+                        3
+                    ],
+                    field_type: Some(
+                        POINT
+                    ),
+                    geometry: [
+                        9,
+                        490,
+                        6262
+                    ],
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                }
+            ],
+            keys: [
+                "hello",
+                "h",
+                "count"
+            ],
+            values: [
+                Tile_Value {
+                    string_value: Some("world"),
+                    float_value: None,
+                    double_value: None,
+                    int_value: None,
+                    uint_value: None,
+                    sint_value: None,
+                    bool_value: None,
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                },
+                Tile_Value {
+                    string_value: None,
+                    float_value: None,
+                    double_value: Some(
+                        1.23
+                    ),
+                    int_value: None,
+                    uint_value: None,
+                    sint_value: None,
+                    bool_value: None,
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                },
+                Tile_Value {
+                    string_value: Some("again"),
+                    float_value: None,
+                    double_value: None,
+                    int_value: None,
+                    uint_value: None,
+                    sint_value: None,
+                    bool_value: None,
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                },
+                Tile_Value {
+                    string_value: None,
+                    float_value: None,
+                    double_value: None,
+                    int_value: Some(
+                        2
+                    ),
+                    uint_value: None,
+                    sint_value: None,
+                    bool_value: None,
+                    unknown_fields: UnknownFields {
+                        fields: None
+                    },
+                    cached_size: CachedSize {
+                        size: Cell {
+                            value: 0
+                        }
+                    }
+                }
+            ],
+            extent: Some(
+                4096
+            ),
+            unknown_fields: UnknownFields {
+                fields: None
+            },
+            cached_size: CachedSize {
+                size: Cell {
+                    value: 0
+                }
+            }
+        }
+    ],
+    unknown_fields: UnknownFields {
+        fields: None
+    },
+    cached_size: CachedSize {
+        size: Cell {
+            value: 0
+        }
+    }
+}"#;

--- a/src/mvt/encoder.rs
+++ b/src/mvt/encoder.rs
@@ -1,0 +1,29 @@
+use protobuf;
+use protobuf::core::Message;
+use protobuf::error::ProtobufError;
+use protobuf::stream::CodedOutputStream;
+use std::io::{BufReader, Read, Write};
+use mvt::proto;
+
+pub trait Encode {
+    fn to_writer(&self, out: &mut Write) -> Result<(), ProtobufError>;
+}
+
+pub trait Decode {
+    fn from_reader(input: &mut Read) -> Result<Self, ProtobufError> where Self: Sized;
+}
+
+impl Encode for proto::Tile {
+    fn to_writer(&self, mut out: &mut Write) -> Result<(), ProtobufError> {
+        let mut os = CodedOutputStream::new(&mut out);
+        let _ = self.write_to(&mut os);
+        os.flush()
+    }
+}
+
+impl Decode for proto::Tile {
+    fn from_reader(input: &mut Read) -> Result<Self, ProtobufError> {
+        let mut reader = BufReader::new(input);
+        protobuf::parse_from_reader(&mut reader)
+    }
+}

--- a/src/mvt/geom.rs
+++ b/src/mvt/geom.rs
@@ -1,0 +1,10 @@
+use postgis::ewkb;
+
+pub type Point = ewkb::Point;
+pub type LineString = ewkb::LineString;
+pub type Polygon = ewkb::Polygon;
+pub type MultiPoint = ewkb::MultiPoint;
+pub type MultiLineString = ewkb::MultiLineString;
+pub type MultiPolygon = ewkb::MultiPolygon;
+pub type GeometryCollection = ewkb::GeometryCollection;
+pub type Geometry = ewkb::Geometry;

--- a/src/mvt/geom_encoder.rs
+++ b/src/mvt/geom_encoder.rs
@@ -1,0 +1,325 @@
+//! Encode geometries according to MVT spec
+//! https://github.com/mapbox/proto-tile-spec/tree/master/2.1
+
+use mvt::geom;
+use mvt::grid;
+use mvt::screen;
+use mvt::proto;
+use postgis::ewkb;
+
+/// Command to be executed and the number of times that the command will be executed
+/// https://github.com/mapbox/proto-tile-spec/tree/master/2.1#431-command-integers
+struct CommandInteger(u32);
+
+enum Command {
+    MoveTo = 1,
+    LineTo = 2,
+    ClosePath = 7,
+}
+
+impl CommandInteger {
+    fn new(id: Command, count: u32) -> CommandInteger {
+        CommandInteger(((id as u32) & 0x7) | (count << 3))
+    }
+    #[cfg(test)]
+    fn id(&self) -> u32 {
+        self.0 & 0x7
+    }
+    #[cfg(test)]
+    fn count(&self) -> u32 {
+        self.0 >> 3
+    }
+}
+
+#[test]
+fn test_commands() {
+    assert_eq!(CommandInteger(9).id(), Command::MoveTo as u32);
+    assert_eq!(CommandInteger(9).count(), 1);
+
+    assert_eq!(CommandInteger::new(Command::MoveTo, 1).0, 9);
+    assert_eq!(CommandInteger::new(Command::LineTo, 3).0, 26);
+    assert_eq!(CommandInteger::new(Command::ClosePath, 1).0, 15);
+}
+
+
+/// Commands requiring parameters are followed by a ParameterInteger for each parameter required by that command
+/// https://github.com/mapbox/proto-tile-spec/tree/master/2.1#432-parameter-integers
+struct ParameterInteger(u32);
+
+impl ParameterInteger {
+    fn new(value: i32) -> ParameterInteger {
+        ParameterInteger(((value << 1) ^ (value >> 31)) as u32)
+    }
+    #[cfg(test)]
+    fn value(&self) -> i32 {
+        ((self.0 >> 1) as i32) ^ (-((self.0 & 1) as i32))
+    }
+}
+
+#[test]
+fn test_paremeters() {
+    assert_eq!(ParameterInteger(50).value(), 25);
+    assert_eq!(ParameterInteger::new(25).value(), 25);
+}
+
+
+pub struct CommandSequence(pub Vec<u32>);
+
+impl CommandSequence {
+    fn new() -> CommandSequence {
+        CommandSequence(Vec::new())
+    }
+    pub fn vec(&self) -> Vec<u32> {
+        self.0.clone() // FIXME: ref
+    }
+    #[cfg(test)]
+    fn append(&mut self, other: &mut CommandSequence) {
+        self.0.append(&mut other.0);
+    }
+    fn push(&mut self, value: u32) {
+        self.0.push(value);
+    }
+}
+
+#[test]
+fn test_sequence() {
+    let mut seq = CommandSequence::new();
+    seq.push(CommandInteger::new(Command::MoveTo, 1).0);
+    seq.push(ParameterInteger::new(25).0);
+    seq.push(ParameterInteger::new(17).0);
+    assert_eq!(seq.0, &[9, 50, 34]);
+
+    let mut seq2 = CommandSequence::new();
+    seq2.push(CommandInteger::new(Command::MoveTo, 1).0);
+    seq.append(&mut seq2);
+    assert_eq!(seq.0, &[9, 50, 34, 9]);
+}
+
+pub fn encode_geometry(bbox: &grid::Extent,
+                       scale: u32,
+                       reverse_y: bool,
+                       geom: geom::Geometry)
+                       -> CommandSequence {
+    match geom {
+        ewkb::GeometryT::Point(ref g) => {
+            screen::Point::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::MultiPoint(ref g) => {
+            screen::MultiPoint::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::LineString(ref g) => {
+            screen::LineString::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::MultiLineString(ref g) => {
+            screen::MultiLineString::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::Polygon(ref g) => {
+            screen::Polygon::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::MultiPolygon(ref g) => {
+            screen::MultiPolygon::from_geom(bbox, scale, reverse_y, g).encode()
+        }
+        ewkb::GeometryT::GeometryCollection(_) => panic!("GeometryCollection not supported"),
+    }
+}
+
+pub fn encode_geometry_type(g: &geom::Geometry) -> proto::Tile_GeomType {
+    match g {
+        &ewkb::GeometryT::Point(_) => proto::Tile_GeomType::POINT,
+        &ewkb::GeometryT::LineString(_) => proto::Tile_GeomType::LINESTRING,
+        &ewkb::GeometryT::Polygon(_) => proto::Tile_GeomType::POLYGON,
+        &ewkb::GeometryT::MultiPoint(_) => proto::Tile_GeomType::POINT,
+        &ewkb::GeometryT::MultiLineString(_) => proto::Tile_GeomType::LINESTRING,
+        &ewkb::GeometryT::MultiPolygon(_) => proto::Tile_GeomType::POLYGON,
+        &ewkb::GeometryT::GeometryCollection(_) => proto::Tile_GeomType::UNKNOWN,
+    }
+}
+
+pub trait EncodableGeom {
+    fn encode(&self) -> CommandSequence {
+        let mut seq = CommandSequence::new();
+        self.encode_from(&screen::Point::origin(), &mut seq);
+        seq
+    }
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence);
+}
+
+impl EncodableGeom for screen::Point {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        seq.push(CommandInteger::new(Command::MoveTo, 1).0);
+        seq.push(ParameterInteger::new(self.x.saturating_sub(startpos.x)).0);
+        seq.push(ParameterInteger::new(self.y.saturating_sub(startpos.y)).0);
+    }
+}
+
+impl EncodableGeom for screen::MultiPoint {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        seq.push(CommandInteger::new(Command::MoveTo, self.points.len() as u32).0);
+        let (mut posx, mut posy) = (startpos.x, startpos.y);
+        for point in &self.points {
+            seq.push(ParameterInteger::new(point.x.saturating_sub(posx)).0);
+            seq.push(ParameterInteger::new(point.y.saturating_sub(posy)).0);
+            posx = point.x;
+            posy = point.y;
+        }
+    }
+}
+
+impl EncodableGeom for screen::LineString {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        if self.points.len() > 0 {
+            self.points[0].encode_from(startpos, seq);
+            seq.push(CommandInteger::new(Command::LineTo, (self.points.len() - 1) as u32).0);
+            for i in 1..self.points.len() {
+                let ref pos = &self.points[i - 1];
+                let ref point = &self.points[i];
+                seq.push(ParameterInteger::new(point.x.saturating_sub(pos.x)).0);
+                seq.push(ParameterInteger::new(point.y.saturating_sub(pos.y)).0);
+            }
+        }
+    }
+}
+impl screen::LineString {
+    fn encode_ring_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        // almost same as LineString.encode_from, with ClosePath instead of last point
+        if self.points.len() > 0 {
+            self.points[0].encode_from(startpos, seq);
+            seq.push(CommandInteger::new(Command::LineTo, (self.points.len() - 2) as u32).0);
+            for i in 1..self.points.len() - 1 {
+                let ref pos = &self.points[i - 1];
+                let ref point = &self.points[i];
+                seq.push(ParameterInteger::new(point.x.saturating_sub(pos.x)).0);
+                seq.push(ParameterInteger::new(point.y.saturating_sub(pos.y)).0);
+            }
+            seq.push(CommandInteger::new(Command::ClosePath, 1).0);
+        }
+    }
+}
+
+impl EncodableGeom for screen::MultiLineString {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        let mut pos = startpos;
+        for line in &self.lines {
+            if line.points.len() > 0 {
+                line.encode_from(&pos, seq);
+                pos = &line.points[line.points.len() - 1];
+            }
+        }
+    }
+}
+
+impl EncodableGeom for screen::Polygon {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        let mut pos = startpos;
+        for line in &self.rings {
+            if line.points.len() > 1 {
+                line.encode_ring_from(&pos, seq);
+                pos = &line.points[line.points.len() - 2];
+            }
+        }
+    }
+}
+
+impl EncodableGeom for screen::MultiPolygon {
+    fn encode_from(&self, startpos: &screen::Point, seq: &mut CommandSequence) {
+        let mut pos = startpos;
+        for polygon in &self.polygons {
+            for line in &polygon.rings {
+                if line.points.len() > 1 {
+                    line.encode_ring_from(&pos, seq);
+                    pos = &line.points[line.points.len() - 2];
+                }
+            }
+        }
+    }
+}
+
+pub trait ScreenGeom<T> {
+    /// Convert geometry into screen coordinates
+    fn from_geom(bbox: &grid::Extent, scale: u32, reverse_y: bool, geom: &T) -> Self;
+}
+
+impl ScreenGeom<geom::Point> for screen::Point {
+    fn from_geom(bbox: &grid::Extent, scale: u32, reverse_y: bool, point: &geom::Point) -> Self {
+        let x_span = bbox.maxx - bbox.minx;
+        let y_span = bbox.maxy - bbox.miny;
+        let mut screen_geom = screen::Point {
+            x: ((point.x - bbox.minx) * scale as f64 / x_span) as i32,
+            y: ((point.y - bbox.miny) * scale as f64 / y_span) as i32,
+        };
+        if reverse_y {
+            screen_geom.y = (scale as i32).saturating_sub(screen_geom.y)
+        };
+        screen_geom
+    }
+}
+
+impl ScreenGeom<geom::MultiPoint> for screen::MultiPoint {
+    fn from_geom(bbox: &grid::Extent,
+                 scale: u32,
+                 reverse_y: bool,
+                 multipoint: &geom::MultiPoint)
+                 -> Self {
+        let mut screen_geom = screen::MultiPoint { points: Vec::new() };
+        for point in &multipoint.points {
+            screen_geom.points.push(screen::Point::from_geom(bbox, scale, reverse_y, point));
+        }
+        screen_geom
+    }
+}
+
+impl ScreenGeom<geom::LineString> for screen::LineString {
+    fn from_geom(bbox: &grid::Extent,
+                 scale: u32,
+                 reverse_y: bool,
+                 line: &geom::LineString)
+                 -> Self {
+        let mut screen_geom = screen::LineString { points: Vec::new() };
+        for point in &line.points {
+            screen_geom.points.push(screen::Point::from_geom(bbox, scale, reverse_y, point));
+        }
+        screen_geom
+    }
+}
+
+impl ScreenGeom<geom::MultiLineString> for screen::MultiLineString {
+    fn from_geom(bbox: &grid::Extent,
+                 scale: u32,
+                 reverse_y: bool,
+                 multiline: &geom::MultiLineString)
+                 -> Self {
+        let mut screen_geom = screen::MultiLineString { lines: Vec::new() };
+        for line in &multiline.lines {
+            screen_geom.lines.push(screen::LineString::from_geom(bbox, scale, reverse_y, line));
+        }
+        screen_geom
+    }
+}
+
+impl ScreenGeom<geom::Polygon> for screen::Polygon {
+    fn from_geom(bbox: &grid::Extent,
+                 scale: u32,
+                 reverse_y: bool,
+                 polygon: &geom::Polygon)
+                 -> Self {
+        let mut screen_geom = screen::Polygon { rings: Vec::new() };
+        for line in &polygon.rings {
+            screen_geom.rings.push(screen::LineString::from_geom(bbox, scale, reverse_y, line));
+        }
+        screen_geom
+    }
+}
+
+impl ScreenGeom<geom::MultiPolygon> for screen::MultiPolygon {
+    fn from_geom(bbox: &grid::Extent,
+                 scale: u32,
+                 reverse_y: bool,
+                 multipolygon: &geom::MultiPolygon)
+                 -> Self {
+        let mut screen_geom = screen::MultiPolygon { polygons: Vec::new() };
+        for polygon in &multipolygon.polygons {
+            screen_geom.polygons.push(screen::Polygon::from_geom(bbox, scale, reverse_y, polygon));
+        }
+        screen_geom
+    }
+}

--- a/src/mvt/geom_encoder_test.rs
+++ b/src/mvt/geom_encoder_test.rs
@@ -1,0 +1,104 @@
+use screen;
+use geom_encoder::EncodableGeom;
+
+#[test]
+fn test_geom_encoding() {
+    let point = screen::Point { x: 25, y: 17 };
+    assert_eq!(point.encode().0, &[9, 50, 34]);
+
+    let multipoint = screen::MultiPoint {
+        points: vec![screen::Point { x: 5, y: 7 }, screen::Point { x: 3, y: 2 }],
+    };
+    assert_eq!(multipoint.encode().0, &[17, 10, 14, 3, 9]);
+
+    let linestring = screen::LineString {
+        points: vec![screen::Point { x: 2, y: 2 },
+                     screen::Point { x: 2, y: 10 },
+                     screen::Point { x: 10, y: 10 }],
+    };
+    assert_eq!(linestring.encode().0, &[9, 4, 4, 18, 0, 16, 16, 0]);
+
+    let multilinestring = screen::MultiLineString {
+        lines: vec![screen::LineString {
+                        points: vec![screen::Point { x: 2, y: 2 },
+                                     screen::Point { x: 2, y: 10 },
+                                     screen::Point { x: 10, y: 10 }],
+                    },
+                    screen::LineString {
+                        points: vec![screen::Point { x: 1, y: 1 }, screen::Point { x: 3, y: 5 }],
+                    }],
+    };
+    assert_eq!(multilinestring.encode().0,
+               &[9, 4, 4, 18, 0, 16, 16, 0, 9, 17, 17, 10, 4, 8]);
+
+    let polygon = screen::Polygon {
+        rings: vec![screen::LineString {
+                        points: vec![screen::Point { x: 3, y: 6 },
+                                     screen::Point { x: 8, y: 12 },
+                                     screen::Point { x: 20, y: 34 },
+                                     screen::Point { x: 3, y: 6 }],
+                    }],
+    };
+    assert_eq!(polygon.encode().0, &[9, 6, 12, 18, 10, 12, 24, 44, 15]);
+
+    let multipolygon = screen::MultiPolygon {
+        polygons: vec![screen::Polygon {
+                           rings: vec![screen::LineString {
+                                           points: vec![screen::Point { x: 0, y: 0 },
+                                                        screen::Point { x: 10, y: 0 },
+                                                        screen::Point { x: 10, y: 10 },
+                                                        screen::Point { x: 0, y: 10 },
+                                                        screen::Point { x: 0, y: 0 }],
+                                       }],
+                       },
+                       screen::Polygon {
+                           rings: vec![screen::LineString {
+                                           points: vec![screen::Point { x: 11, y: 11 },
+                                                        screen::Point { x: 20, y: 11 },
+                                                        screen::Point { x: 20, y: 20 },
+                                                        screen::Point { x: 11, y: 20 },
+                                                        screen::Point { x: 11, y: 20 },
+                                                        screen::Point { x: 11, y: 11 }],
+                                       },
+                                       screen::LineString {
+                                           points: vec![screen::Point { x: 13, y: 13 },
+                                                        screen::Point { x: 13, y: 17 },
+                                                        screen::Point { x: 17, y: 17 },
+                                                        screen::Point { x: 17, y: 13 },
+                                                        screen::Point { x: 13, y: 13 }],
+                                       }],
+                       }],
+    };
+    let expected = [9, 0, 0, 26, 20, 0, 0, 20, 19, 0, 15, 9, 22, 2, 34, 18, 0, 0, 18, 17, 0, 0, 0,
+                    15, 9, 4, 13, 26, 0, 8, 8, 0, 0, 7, 15];
+    assert_eq!(multipolygon.encode().0, &expected[0..35]);
+}
+
+#[test]
+fn test_overflow() {
+    use std::i32;
+    use std::u32;
+
+    assert_eq!(i32::MIN, -2147483648);
+    assert_eq!(i32::MAX, 2147483647);
+    assert_eq!(u32::MAX, 4294967295);
+
+    let multipoint = screen::MultiPoint {
+        points: vec![screen::Point { x: 5, y: 7 },
+                     screen::Point {
+                         x: i32::MIN,
+                         y: i32::MIN,
+                     }],
+    };
+    assert_eq!(multipoint.encode().0, &[17, 10, 14, u32::MAX, u32::MAX]);
+
+    let multipoint = screen::MultiPoint {
+        points: vec![screen::Point { x: -5, y: -10 },
+                     screen::Point {
+                         x: i32::MAX,
+                         y: i32::MAX,
+                     }],
+    };
+    assert_eq!(multipoint.encode().0,
+               &[17, 9, 19, u32::MAX - 1, u32::MAX - 1]);
+}

--- a/src/mvt/grid.rs
+++ b/src/mvt/grid.rs
@@ -1,0 +1,259 @@
+#[derive(Debug, PartialEq)]
+pub struct Extent {
+    pub minx: f64,
+    pub miny: f64,
+    pub maxx: f64,
+    pub maxy: f64,
+}
+
+/// Min and max grid cell numbers
+#[derive(Debug, PartialEq)]
+pub struct ExtentInt {
+    pub minx: u32,
+    pub miny: u32,
+    pub maxx: u32,
+    pub maxy: u32,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Origin {
+    TopLeft,
+    BottomLeft, // TopRight, BottomRight
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Unit {
+    M,
+    DD,
+    Ft,
+}
+
+// Credits: MapCache by Thomas Bonfort (http://mapserver.org/mapcache/)
+#[derive(Debug)]
+pub struct Grid {
+    /// The width and height of an individual tile, in pixels.
+    width: u16,
+    height: u16,
+    /// The geographical extent covered by the grid, in ground units (e.g. meters, degrees, feet, etc.).
+    /// Must be specified as 4 floating point numbers ordered as minx, miny, maxx, maxy.
+    /// The (minx,miny) point defines the origin of the grid, i.e. the pixel at the bottom left of the
+    /// bottom-left most tile is always placed on the (minx,miny) geographical point.
+    /// The (maxx,maxy) point is used to determine how many tiles there are for each zoom level.
+    pub extent: Extent,
+    /// Spatial reference system (PostGIS SRID).
+    pub srid: i32,
+    /// Grid units
+    pub units: Unit,
+    /// This is a list of resolutions for each of the zoom levels defined by the grid.
+    /// This must be supplied as a list of positive floating point values, ordered from largest to smallest.
+    /// The largest value will correspond to the grid’s zoom level 0. Resolutions
+    /// are expressed in “units-per-pixel”,
+    /// depending on the unit used by the grid (e.g. resolutions are in meters per
+    /// pixel for most grids used in webmapping).
+    resolutions: Vec<f64>,
+    /// Grid origin
+    pub origin: Origin,
+    /// Whether y tiles go from South->North (normal) or North->South (reversed)
+    pub reverse_y: bool,
+}
+
+impl Grid {
+    /// WGS84 grid
+    pub fn wgs84() -> Grid {
+        Grid {
+            width: 256,
+            height: 256,
+            extent: Extent {
+                minx: -180.0,
+                miny: -90.0,
+                maxx: 180.0,
+                maxy: 90.0,
+            },
+            srid: 4326,
+            units: Unit::DD,
+            resolutions: vec![0.703125000000000,
+                              0.351562500000000,
+                              0.175781250000000,
+                              8.78906250000000e-2,
+                              4.39453125000000e-2,
+                              2.19726562500000e-2,
+                              1.09863281250000e-2,
+                              5.49316406250000e-3,
+                              2.74658203125000e-3,
+                              1.37329101562500e-3,
+                              6.86645507812500e-4,
+                              3.43322753906250e-4,
+                              1.71661376953125e-4,
+                              8.58306884765625e-5,
+                              4.29153442382812e-5,
+                              2.14576721191406e-5,
+                              1.07288360595703e-5,
+                              5.36441802978516e-6],
+            origin: Origin::BottomLeft,
+            reverse_y: false,
+        }
+    }
+
+    /// Web Mercator grid (Google maps compatible)
+    pub fn web_mercator() -> Grid {
+        Grid {
+            width: 256,
+            height: 256,
+            extent: Extent {
+                minx: -20037508.3427892480,
+                miny: -20037508.3427892480,
+                maxx: 20037508.3427892480,
+                maxy: 20037508.3427892480,
+            },
+            srid: 3857,
+            units: Unit::M,
+            resolutions: vec![156543.0339280410,
+                              78271.51696402048,
+                              39135.75848201023,
+                              19567.87924100512,
+                              9783.939620502561,
+                              4891.969810251280,
+                              2445.984905125640,
+                              1222.992452562820,
+                              611.4962262814100,
+                              305.7481131407048,
+                              152.8740565703525,
+                              76.43702828517624,
+                              38.21851414258813,
+                              19.10925707129406,
+                              9.554628535647032,
+                              4.777314267823516,
+                              2.388657133911758,
+                              1.194328566955879,
+                              0.5971642834779395,
+                              0.2985821417389700,
+                              0.1492910708694850,
+                              0.0746455354347424,
+                              0.0373227677173712],
+            origin: Origin::BottomLeft,
+            reverse_y: true,
+        }
+    }
+
+    pub fn nlevels(&self) -> u8 {
+        self.resolutions.len() as u8
+    }
+    pub fn maxzoom(&self) -> u8 {
+        self.nlevels() - 1
+    }
+    pub fn pixel_width(&self, zoom: u8) -> f64 {
+        self.resolutions[zoom as usize] //TODO: assumes grid unit 'm'
+    }
+    pub fn scale_denominator(&self, zoom: u8) -> f64 {
+        let pixel_screen_width = 0.0254 / 96.0; //FIXME: assumes 96dpi - check with mapnik
+        self.pixel_width(zoom) / pixel_screen_width
+    }
+    /// Extent of a given tile in the grid given its x, y, and z in TMS adressing scheme
+    pub fn tile_extent(&self, z: u8, x: u32, y: u32) -> Extent {
+        let zoom = z;
+        let xtile = x;
+        let ytile = if self.reverse_y {
+            let res = self.resolutions[zoom as usize];
+            let unitheight = self.height as f64 * res;
+            let maxy = ((self.extent.maxy - self.extent.minx - 0.01 * unitheight) / unitheight)
+                .ceil() as u32;
+            maxy.saturating_sub(y).saturating_sub(1)
+        } else {
+            y
+        };
+
+        // based on mapcache_grid_get_tile_extent
+        let res = self.resolutions[zoom as usize];
+        let tile_sx = self.width as f64;
+        let tile_sy = self.height as f64;
+        match self.origin {
+            Origin::BottomLeft => {
+                Extent {
+                    minx: self.extent.minx + (res * xtile as f64 * tile_sx),
+                    miny: self.extent.miny + (res * ytile as f64 * tile_sy),
+                    maxx: self.extent.minx + (res * (xtile + 1) as f64 * tile_sx),
+                    maxy: self.extent.miny + (res * (ytile + 1) as f64 * tile_sy),
+                }
+            }
+            Origin::TopLeft => {
+                Extent {
+                    minx: self.extent.minx + (res * xtile as f64 * tile_sx),
+                    miny: self.extent.maxy - (res * (ytile + 1) as f64 * tile_sy),
+                    maxx: self.extent.minx + (res * (xtile + 1) as f64 * tile_sx),
+                    maxy: self.extent.maxy - (res * ytile as f64 * tile_sy),
+                }
+            }
+        }
+    }
+    /// (maxx, maxy) of grid level
+    pub fn level_limit(&self, zoom: u8) -> (u32, u32) {
+        let res = self.resolutions[zoom as usize];
+        let unitheight = self.height as f64 * res;
+        let unitwidth = self.width as f64 * res;
+
+        let maxy = ((self.extent.maxy - self.extent.miny - 0.01 * unitheight) / unitheight)
+            .ceil() as u32;
+        let maxx = ((self.extent.maxx - self.extent.miny - 0.01 * unitwidth) / unitwidth)
+            .ceil() as u32;
+        (maxx, maxy)
+    }
+    /// Tile index limits covering extent
+    pub fn tile_limits(&self, extent: Extent, tolerance: i32) -> Vec<ExtentInt> {
+        // Based on mapcache_grid_compute_limits
+        const EPSILON: f64 = 0.0000001;
+        let nlevels = self.resolutions.len() as u8;
+        (0..nlevels)
+            .map(|i| {
+                let res = self.resolutions[i as usize];
+                let unitheight = self.height as f64 * res;
+                let unitwidth = self.width as f64 * res;
+                let (level_maxx, level_maxy) = self.level_limit(i);
+
+                let (mut minx, mut maxx, mut miny, mut maxy) =
+                    match self.origin {
+                        Origin::BottomLeft => {
+                            ((((extent.minx - self.extent.minx) / unitwidth + EPSILON)
+                                .floor() as i32) - tolerance,
+                             (((extent.maxx - self.extent.minx) / unitwidth - EPSILON)
+                                .ceil() as i32) + tolerance,
+                             (((extent.miny - self.extent.miny) / unitheight + EPSILON)
+                                .floor() as i32) - tolerance,
+                             (((extent.maxy - self.extent.miny) / unitheight - EPSILON)
+                                .ceil() as i32) + tolerance)
+                        }
+                        Origin::TopLeft => {
+                            ((((extent.minx - self.extent.minx) / unitwidth + EPSILON)
+                                .floor() as i32) - tolerance,
+                             (((extent.maxx - self.extent.minx) / unitwidth - EPSILON)
+                                .ceil() as i32) + tolerance,
+                             (((self.extent.maxy - extent.maxy) / unitheight + EPSILON)
+                                .floor() as i32) - tolerance,
+                             (((self.extent.maxy - extent.miny) / unitheight - EPSILON)
+                                .ceil() as i32) + tolerance)
+                        }
+                    };
+
+                // to avoid requesting out-of-range tiles
+                if minx < 0 {
+                    minx = 0;
+                }
+                if maxx > level_maxx as i32 {
+                    maxx = level_maxx as i32
+                };
+                if miny < 0 {
+                    miny = 0
+                };
+                if maxy > level_maxy as i32 {
+                    maxy = level_maxy as i32
+                };
+
+                ExtentInt {
+                    minx: minx as u32,
+                    maxx: maxx as u32,
+                    miny: miny as u32,
+                    maxy: maxy as u32,
+                }
+            })
+            .collect()
+    }
+}

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -1,0 +1,67 @@
+extern crate postgis;
+extern crate protobuf;
+
+use r2d2; 
+use r2d2_postgres;
+
+mod builder;
+mod encoder;
+pub mod geom_encoder;
+pub mod geom;
+pub mod grid;
+pub mod screen;
+
+#[cfg_attr(rustfmt, rustfmt_skip)]
+pub mod proto; // protoc --rust_out . proto.proto
+
+#[cfg(test)]
+mod builder_test;
+
+#[cfg(test)]
+mod geom_encoder_test;
+
+pub use self::builder::{Tile, Layer, Feature, Value};
+pub use self::encoder::{Decode, Encode};
+pub use self::grid::{Grid};
+
+#[derive(PartialEq)]
+#[derive(Debug)]
+pub enum MVTError {
+    NotFound
+}
+
+impl MVTError {
+    pub fn to_string(&self) -> String {
+        match *self {
+            MVTError::NotFound => { String::from("Tile not found") }
+
+        }
+    }
+}
+
+pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32) -> Result<i64, MVTError> {
+    let grid = Grid::web_mercator();
+    let bbox = grid.tile_extent(z, x, y);
+    let mut tile = Tile::new(&bbox);
+
+    let layer = Layer::new("data");
+
+    let rows = conn.query("
+        SELECT
+            id,
+            ST_Transform(geom::geometry,3857),
+            GeometryType(geom)
+        FROM geo
+        WHERE
+            geom
+            && ST_Transform(ST_MakeEnvelope($1, $2, $3, $4, $5), 4326)
+    ", &[&bbox.minx, &bbox.miny, &bbox.maxx, &bbox.maxy, &grid.srid]).unwrap();
+
+    for row in rows.iter() {
+    }
+    tile.add_layer(layer);
+
+    let encoded = tile.encode(&grid);
+
+    Ok(1)
+}

--- a/src/mvt/proto.proto
+++ b/src/mvt/proto.proto
@@ -1,0 +1,78 @@
+package proto;
+
+option optimize_for = LITE_RUNTIME;
+
+message Tile {
+
+        // GeomType is described in section 4.3.4 of the specification
+        enum GeomType {
+             UNKNOWN = 0;
+             POINT = 1;
+             LINESTRING = 2;
+             POLYGON = 3;
+        }
+
+        // Variant type encoding
+        // The use of values is described in section 4.1 of the specification
+        message Value {
+                // Exactly one of these values must be present in a valid message
+                optional string string_value = 1;
+                optional float float_value = 2;
+                optional double double_value = 3;
+                optional int64 int_value = 4;
+                optional uint64 uint_value = 5;
+                optional sint64 sint_value = 6;
+                optional bool bool_value = 7;
+
+                extensions 8 to max;
+        }
+
+        // Features are described in section 4.2 of the specification
+        message Feature {
+                optional uint64 id = 1 [ default = 0 ];
+
+                // Tags of this feature are encoded as repeated pairs of
+                // integers.
+                // A detailed description of tags is located in sections
+                // 4.2 and 4.4 of the specification
+                repeated uint32 tags = 2 [ packed = true ];
+
+                // The type of geometry stored in this feature.
+                optional GeomType type = 3 [ default = UNKNOWN ];
+
+                // Contains a stream of commands and parameters (vertices).
+                // A detailed description on geometry encoding is located in
+                // section 4.3 of the specification.
+                repeated uint32 geometry = 4 [ packed = true ];
+        }
+
+        // Layers are described in section 4.1 of the specification
+        message Layer {
+                // Any compliant implementation must first read the version
+                // number encoded in this message and choose the correct
+                // implementation for this version number before proceeding to
+                // decode other parts of this message.
+                required uint32 version = 15 [ default = 1 ];
+
+                required string name = 1;
+
+                // The actual features in this tile.
+                repeated Feature features = 2;
+
+                // Dictionary encoding for keys
+                repeated string keys = 3;
+
+                // Dictionary encoding for values
+                repeated Value values = 4;
+
+                // Although this is an "optional" field it is required by the specification.
+                // See https://github.com/mapbox/vector-tile-spec/issues/47
+                optional uint32 extent = 5 [ default = 4096 ];
+
+                extensions 16 to max;
+        }
+
+        repeated Layer layers = 3;
+
+        extensions 16 to 8191;
+}

--- a/src/mvt/proto.rs
+++ b/src/mvt/proto.rs
@@ -1,0 +1,1266 @@
+// This file is generated. Do not edit
+// @generated
+
+// https://github.com/Manishearth/rust-clippy/issues/702
+#![allow(unknown_lints)]
+#![allow(clippy)]
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
+#![allow(box_pointers)]
+#![allow(dead_code)]
+#![allow(missing_docs)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(trivial_casts)]
+#![allow(unsafe_code)]
+#![allow(unused_imports)]
+#![allow(unused_results)]
+
+use protobuf::Message as Message_imported_for_functions;
+use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
+
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct Tile {
+    // message fields
+    layers: ::protobuf::RepeatedField<Tile_Layer>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Tile {}
+
+impl Tile {
+    pub fn new() -> Tile {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Tile {
+        static mut instance: ::protobuf::lazy::Lazy<Tile> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Tile,
+        };
+        unsafe {
+            instance.get(Tile::new)
+        }
+    }
+
+    // repeated .vector_tile.Tile.Layer layers = 3;
+
+    pub fn clear_layers(&mut self) {
+        self.layers.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_layers(&mut self, v: ::protobuf::RepeatedField<Tile_Layer>) {
+        self.layers = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_layers(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Layer> {
+        &mut self.layers
+    }
+
+    // Take field
+    pub fn take_layers(&mut self) -> ::protobuf::RepeatedField<Tile_Layer> {
+        ::std::mem::replace(&mut self.layers, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_layers(&self) -> &[Tile_Layer] {
+        &self.layers
+    }
+
+    fn get_layers_for_reflect(&self) -> &::protobuf::RepeatedField<Tile_Layer> {
+        &self.layers
+    }
+
+    fn mut_layers_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Layer> {
+        &mut self.layers
+    }
+}
+
+impl ::protobuf::Message for Tile {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                3 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.layers)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        for value in &self.layers {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        for v in &self.layers {
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Tile {
+    fn new() -> Tile {
+        Tile::new()
+    }
+}
+
+impl ::protobuf::Clear for Tile {
+    fn clear(&mut self) {
+        self.clear_layers();
+        self.unknown_fields.clear();
+    }
+}
+
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct Tile_Value {
+    // message fields
+    string_value: ::protobuf::SingularField<::std::string::String>,
+    float_value: ::std::option::Option<f32>,
+    double_value: ::std::option::Option<f64>,
+    int_value: ::std::option::Option<i64>,
+    uint_value: ::std::option::Option<u64>,
+    sint_value: ::std::option::Option<i64>,
+    bool_value: ::std::option::Option<bool>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Tile_Value {}
+
+impl Tile_Value {
+    pub fn new() -> Tile_Value {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Tile_Value {
+        static mut instance: ::protobuf::lazy::Lazy<Tile_Value> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Tile_Value,
+        };
+        unsafe {
+            instance.get(Tile_Value::new)
+        }
+    }
+
+    // optional string string_value = 1;
+
+    pub fn clear_string_value(&mut self) {
+        self.string_value.clear();
+    }
+
+    pub fn has_string_value(&self) -> bool {
+        self.string_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_string_value(&mut self, v: ::std::string::String) {
+        self.string_value = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_string_value(&mut self) -> &mut ::std::string::String {
+        if self.string_value.is_none() {
+            self.string_value.set_default();
+        };
+        self.string_value.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_string_value(&mut self) -> ::std::string::String {
+        self.string_value.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_string_value(&self) -> &str {
+        match self.string_value.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_string_value_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.string_value
+    }
+
+    fn mut_string_value_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.string_value
+    }
+
+    // optional float float_value = 2;
+
+    pub fn clear_float_value(&mut self) {
+        self.float_value = ::std::option::Option::None;
+    }
+
+    pub fn has_float_value(&self) -> bool {
+        self.float_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_float_value(&mut self, v: f32) {
+        self.float_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_float_value(&self) -> f32 {
+        self.float_value.unwrap_or(0.)
+    }
+
+    fn get_float_value_for_reflect(&self) -> &::std::option::Option<f32> {
+        &self.float_value
+    }
+
+    fn mut_float_value_for_reflect(&mut self) -> &mut ::std::option::Option<f32> {
+        &mut self.float_value
+    }
+
+    // optional double double_value = 3;
+
+    pub fn clear_double_value(&mut self) {
+        self.double_value = ::std::option::Option::None;
+    }
+
+    pub fn has_double_value(&self) -> bool {
+        self.double_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_double_value(&mut self, v: f64) {
+        self.double_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_double_value(&self) -> f64 {
+        self.double_value.unwrap_or(0.)
+    }
+
+    fn get_double_value_for_reflect(&self) -> &::std::option::Option<f64> {
+        &self.double_value
+    }
+
+    fn mut_double_value_for_reflect(&mut self) -> &mut ::std::option::Option<f64> {
+        &mut self.double_value
+    }
+
+    // optional int64 int_value = 4;
+
+    pub fn clear_int_value(&mut self) {
+        self.int_value = ::std::option::Option::None;
+    }
+
+    pub fn has_int_value(&self) -> bool {
+        self.int_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_int_value(&mut self, v: i64) {
+        self.int_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_int_value(&self) -> i64 {
+        self.int_value.unwrap_or(0)
+    }
+
+    fn get_int_value_for_reflect(&self) -> &::std::option::Option<i64> {
+        &self.int_value
+    }
+
+    fn mut_int_value_for_reflect(&mut self) -> &mut ::std::option::Option<i64> {
+        &mut self.int_value
+    }
+
+    // optional uint64 uint_value = 5;
+
+    pub fn clear_uint_value(&mut self) {
+        self.uint_value = ::std::option::Option::None;
+    }
+
+    pub fn has_uint_value(&self) -> bool {
+        self.uint_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_uint_value(&mut self, v: u64) {
+        self.uint_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_uint_value(&self) -> u64 {
+        self.uint_value.unwrap_or(0)
+    }
+
+    fn get_uint_value_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.uint_value
+    }
+
+    fn mut_uint_value_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.uint_value
+    }
+
+    // optional sint64 sint_value = 6;
+
+    pub fn clear_sint_value(&mut self) {
+        self.sint_value = ::std::option::Option::None;
+    }
+
+    pub fn has_sint_value(&self) -> bool {
+        self.sint_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_sint_value(&mut self, v: i64) {
+        self.sint_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_sint_value(&self) -> i64 {
+        self.sint_value.unwrap_or(0)
+    }
+
+    fn get_sint_value_for_reflect(&self) -> &::std::option::Option<i64> {
+        &self.sint_value
+    }
+
+    fn mut_sint_value_for_reflect(&mut self) -> &mut ::std::option::Option<i64> {
+        &mut self.sint_value
+    }
+
+    // optional bool bool_value = 7;
+
+    pub fn clear_bool_value(&mut self) {
+        self.bool_value = ::std::option::Option::None;
+    }
+
+    pub fn has_bool_value(&self) -> bool {
+        self.bool_value.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_bool_value(&mut self, v: bool) {
+        self.bool_value = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_bool_value(&self) -> bool {
+        self.bool_value.unwrap_or(false)
+    }
+
+    fn get_bool_value_for_reflect(&self) -> &::std::option::Option<bool> {
+        &self.bool_value
+    }
+
+    fn mut_bool_value_for_reflect(&mut self) -> &mut ::std::option::Option<bool> {
+        &mut self.bool_value
+    }
+}
+
+impl ::protobuf::Message for Tile_Value {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.string_value)?;
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeFixed32 {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_float()?;
+                    self.float_value = ::std::option::Option::Some(tmp);
+                },
+                3 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeFixed64 {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_double()?;
+                    self.double_value = ::std::option::Option::Some(tmp);
+                },
+                4 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_int64()?;
+                    self.int_value = ::std::option::Option::Some(tmp);
+                },
+                5 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_uint64()?;
+                    self.uint_value = ::std::option::Option::Some(tmp);
+                },
+                6 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_sint64()?;
+                    self.sint_value = ::std::option::Option::Some(tmp);
+                },
+                7 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_bool()?;
+                    self.bool_value = ::std::option::Option::Some(tmp);
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(v) = self.string_value.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
+        };
+        if let Some(v) = self.float_value {
+            my_size += 5;
+        };
+        if let Some(v) = self.double_value {
+            my_size += 9;
+        };
+        if let Some(v) = self.int_value {
+            my_size += ::protobuf::rt::value_size(4, v, ::protobuf::wire_format::WireTypeVarint);
+        };
+        if let Some(v) = self.uint_value {
+            my_size += ::protobuf::rt::value_size(5, v, ::protobuf::wire_format::WireTypeVarint);
+        };
+        if let Some(v) = self.sint_value {
+            my_size += ::protobuf::rt::value_varint_zigzag_size(6, v);
+        };
+        if let Some(v) = self.bool_value {
+            my_size += 2;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.string_value.as_ref() {
+            os.write_string(1, &v)?;
+        };
+        if let Some(v) = self.float_value {
+            os.write_float(2, v)?;
+        };
+        if let Some(v) = self.double_value {
+            os.write_double(3, v)?;
+        };
+        if let Some(v) = self.int_value {
+            os.write_int64(4, v)?;
+        };
+        if let Some(v) = self.uint_value {
+            os.write_uint64(5, v)?;
+        };
+        if let Some(v) = self.sint_value {
+            os.write_sint64(6, v)?;
+        };
+        if let Some(v) = self.bool_value {
+            os.write_bool(7, v)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Tile_Value {
+    fn new() -> Tile_Value {
+        Tile_Value::new()
+    }
+}
+
+impl ::protobuf::Clear for Tile_Value {
+    fn clear(&mut self) {
+        self.clear_string_value();
+        self.clear_float_value();
+        self.clear_double_value();
+        self.clear_int_value();
+        self.clear_uint_value();
+        self.clear_sint_value();
+        self.clear_bool_value();
+        self.unknown_fields.clear();
+    }
+}
+
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct Tile_Feature {
+    // message fields
+    id: ::std::option::Option<u64>,
+    tags: ::std::vec::Vec<u32>,
+    field_type: ::std::option::Option<Tile_GeomType>,
+    geometry: ::std::vec::Vec<u32>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Tile_Feature {}
+
+impl Tile_Feature {
+    pub fn new() -> Tile_Feature {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Tile_Feature {
+        static mut instance: ::protobuf::lazy::Lazy<Tile_Feature> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Tile_Feature,
+        };
+        unsafe {
+            instance.get(Tile_Feature::new)
+        }
+    }
+
+    // optional uint64 id = 1;
+
+    pub fn clear_id(&mut self) {
+        self.id = ::std::option::Option::None;
+    }
+
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_id(&mut self, v: u64) {
+        self.id = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_id(&self) -> u64 {
+        self.id.unwrap_or(0u64)
+    }
+
+    fn get_id_for_reflect(&self) -> &::std::option::Option<u64> {
+        &self.id
+    }
+
+    fn mut_id_for_reflect(&mut self) -> &mut ::std::option::Option<u64> {
+        &mut self.id
+    }
+
+    // repeated uint32 tags = 2;
+
+    pub fn clear_tags(&mut self) {
+        self.tags.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_tags(&mut self, v: ::std::vec::Vec<u32>) {
+        self.tags = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_tags(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.tags
+    }
+
+    // Take field
+    pub fn take_tags(&mut self) -> ::std::vec::Vec<u32> {
+        ::std::mem::replace(&mut self.tags, ::std::vec::Vec::new())
+    }
+
+    pub fn get_tags(&self) -> &[u32] {
+        &self.tags
+    }
+
+    fn get_tags_for_reflect(&self) -> &::std::vec::Vec<u32> {
+        &self.tags
+    }
+
+    fn mut_tags_for_reflect(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.tags
+    }
+
+    // optional .vector_tile.Tile.GeomType type = 3;
+
+    pub fn clear_field_type(&mut self) {
+        self.field_type = ::std::option::Option::None;
+    }
+
+    pub fn has_field_type(&self) -> bool {
+        self.field_type.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_field_type(&mut self, v: Tile_GeomType) {
+        self.field_type = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_field_type(&self) -> Tile_GeomType {
+        self.field_type.unwrap_or(Tile_GeomType::UNKNOWN)
+    }
+
+    fn get_field_type_for_reflect(&self) -> &::std::option::Option<Tile_GeomType> {
+        &self.field_type
+    }
+
+    fn mut_field_type_for_reflect(&mut self) -> &mut ::std::option::Option<Tile_GeomType> {
+        &mut self.field_type
+    }
+
+    // repeated uint32 geometry = 4;
+
+    pub fn clear_geometry(&mut self) {
+        self.geometry.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_geometry(&mut self, v: ::std::vec::Vec<u32>) {
+        self.geometry = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_geometry(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.geometry
+    }
+
+    // Take field
+    pub fn take_geometry(&mut self) -> ::std::vec::Vec<u32> {
+        ::std::mem::replace(&mut self.geometry, ::std::vec::Vec::new())
+    }
+
+    pub fn get_geometry(&self) -> &[u32] {
+        &self.geometry
+    }
+
+    fn get_geometry_for_reflect(&self) -> &::std::vec::Vec<u32> {
+        &self.geometry
+    }
+
+    fn mut_geometry_for_reflect(&mut self) -> &mut ::std::vec::Vec<u32> {
+        &mut self.geometry
+    }
+}
+
+impl ::protobuf::Message for Tile_Feature {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_uint64()?;
+                    self.id = ::std::option::Option::Some(tmp);
+                },
+                2 => {
+                    ::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.tags)?;
+                },
+                3 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_enum()?;
+                    self.field_type = ::std::option::Option::Some(tmp);
+                },
+                4 => {
+                    ::protobuf::rt::read_repeated_uint32_into(wire_type, is, &mut self.geometry)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(v) = self.id {
+            my_size += ::protobuf::rt::value_size(1, v, ::protobuf::wire_format::WireTypeVarint);
+        };
+        if !self.tags.is_empty() {
+            my_size += ::protobuf::rt::vec_packed_varint_size(2, &self.tags);
+        };
+        if let Some(v) = self.field_type {
+            my_size += ::protobuf::rt::enum_size(3, v);
+        };
+        if !self.geometry.is_empty() {
+            my_size += ::protobuf::rt::vec_packed_varint_size(4, &self.geometry);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.id {
+            os.write_uint64(1, v)?;
+        };
+        if !self.tags.is_empty() {
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            // TODO: Data size is computed again, it should be cached
+            os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.tags))?;
+            for v in &self.tags {
+                os.write_uint32_no_tag(*v)?;
+            };
+        };
+        if let Some(v) = self.field_type {
+            os.write_enum(3, v.value())?;
+        };
+        if !self.geometry.is_empty() {
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            // TODO: Data size is computed again, it should be cached
+            os.write_raw_varint32(::protobuf::rt::vec_packed_varint_data_size(&self.geometry))?;
+            for v in &self.geometry {
+                os.write_uint32_no_tag(*v)?;
+            };
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Tile_Feature {
+    fn new() -> Tile_Feature {
+        Tile_Feature::new()
+    }
+}
+
+impl ::protobuf::Clear for Tile_Feature {
+    fn clear(&mut self) {
+        self.clear_id();
+        self.clear_tags();
+        self.clear_field_type();
+        self.clear_geometry();
+        self.unknown_fields.clear();
+    }
+}
+
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct Tile_Layer {
+    // message fields
+    version: ::std::option::Option<u32>,
+    name: ::protobuf::SingularField<::std::string::String>,
+    features: ::protobuf::RepeatedField<Tile_Feature>,
+    keys: ::protobuf::RepeatedField<::std::string::String>,
+    values: ::protobuf::RepeatedField<Tile_Value>,
+    extent: ::std::option::Option<u32>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+// see codegen.rs for the explanation why impl Sync explicitly
+unsafe impl ::std::marker::Sync for Tile_Layer {}
+
+impl Tile_Layer {
+    pub fn new() -> Tile_Layer {
+        ::std::default::Default::default()
+    }
+
+    pub fn default_instance() -> &'static Tile_Layer {
+        static mut instance: ::protobuf::lazy::Lazy<Tile_Layer> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const Tile_Layer,
+        };
+        unsafe {
+            instance.get(Tile_Layer::new)
+        }
+    }
+
+    // required uint32 version = 15;
+
+    pub fn clear_version(&mut self) {
+        self.version = ::std::option::Option::None;
+    }
+
+    pub fn has_version(&self) -> bool {
+        self.version.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_version(&mut self, v: u32) {
+        self.version = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_version(&self) -> u32 {
+        self.version.unwrap_or(1u32)
+    }
+
+    fn get_version_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.version
+    }
+
+    fn mut_version_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.version
+    }
+
+    // required string name = 1;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    pub fn has_name(&self) -> bool {
+        self.name.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = ::protobuf::SingularField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        if self.name.is_none() {
+            self.name.set_default();
+        };
+        self.name.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    pub fn get_name(&self) -> &str {
+        match self.name.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
+    }
+
+    fn get_name_for_reflect(&self) -> &::protobuf::SingularField<::std::string::String> {
+        &self.name
+    }
+
+    fn mut_name_for_reflect(&mut self) -> &mut ::protobuf::SingularField<::std::string::String> {
+        &mut self.name
+    }
+
+    // repeated .vector_tile.Tile.Feature features = 2;
+
+    pub fn clear_features(&mut self) {
+        self.features.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_features(&mut self, v: ::protobuf::RepeatedField<Tile_Feature>) {
+        self.features = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_features(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Feature> {
+        &mut self.features
+    }
+
+    // Take field
+    pub fn take_features(&mut self) -> ::protobuf::RepeatedField<Tile_Feature> {
+        ::std::mem::replace(&mut self.features, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_features(&self) -> &[Tile_Feature] {
+        &self.features
+    }
+
+    fn get_features_for_reflect(&self) -> &::protobuf::RepeatedField<Tile_Feature> {
+        &self.features
+    }
+
+    fn mut_features_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Feature> {
+        &mut self.features
+    }
+
+    // repeated string keys = 3;
+
+    pub fn clear_keys(&mut self) {
+        self.keys.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_keys(&mut self, v: ::protobuf::RepeatedField<::std::string::String>) {
+        self.keys = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_keys(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.keys
+    }
+
+    // Take field
+    pub fn take_keys(&mut self) -> ::protobuf::RepeatedField<::std::string::String> {
+        ::std::mem::replace(&mut self.keys, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_keys(&self) -> &[::std::string::String] {
+        &self.keys
+    }
+
+    fn get_keys_for_reflect(&self) -> &::protobuf::RepeatedField<::std::string::String> {
+        &self.keys
+    }
+
+    fn mut_keys_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<::std::string::String> {
+        &mut self.keys
+    }
+
+    // repeated .vector_tile.Tile.Value values = 4;
+
+    pub fn clear_values(&mut self) {
+        self.values.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_values(&mut self, v: ::protobuf::RepeatedField<Tile_Value>) {
+        self.values = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_values(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Value> {
+        &mut self.values
+    }
+
+    // Take field
+    pub fn take_values(&mut self) -> ::protobuf::RepeatedField<Tile_Value> {
+        ::std::mem::replace(&mut self.values, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_values(&self) -> &[Tile_Value] {
+        &self.values
+    }
+
+    fn get_values_for_reflect(&self) -> &::protobuf::RepeatedField<Tile_Value> {
+        &self.values
+    }
+
+    fn mut_values_for_reflect(&mut self) -> &mut ::protobuf::RepeatedField<Tile_Value> {
+        &mut self.values
+    }
+
+    // optional uint32 extent = 5;
+
+    pub fn clear_extent(&mut self) {
+        self.extent = ::std::option::Option::None;
+    }
+
+    pub fn has_extent(&self) -> bool {
+        self.extent.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_extent(&mut self, v: u32) {
+        self.extent = ::std::option::Option::Some(v);
+    }
+
+    pub fn get_extent(&self) -> u32 {
+        self.extent.unwrap_or(4096u32)
+    }
+
+    fn get_extent_for_reflect(&self) -> &::std::option::Option<u32> {
+        &self.extent
+    }
+
+    fn mut_extent_for_reflect(&mut self) -> &mut ::std::option::Option<u32> {
+        &mut self.extent
+    }
+}
+
+impl ::protobuf::Message for Tile_Layer {
+    fn is_initialized(&self) -> bool {
+        if self.version.is_none() {
+            return false;
+        };
+        if self.name.is_none() {
+            return false;
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                15 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_uint32()?;
+                    self.version = ::std::option::Option::Some(tmp);
+                },
+                1 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.features)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.keys)?;
+                },
+                4 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.values)?;
+                },
+                5 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    };
+                    let tmp = is.read_uint32()?;
+                    self.extent = ::std::option::Option::Some(tmp);
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(v) = self.version {
+            my_size += ::protobuf::rt::value_size(15, v, ::protobuf::wire_format::WireTypeVarint);
+        };
+        if let Some(v) = self.name.as_ref() {
+            my_size += ::protobuf::rt::string_size(1, &v);
+        };
+        for value in &self.features {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        for value in &self.keys {
+            my_size += ::protobuf::rt::string_size(3, &value);
+        };
+        for value in &self.values {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        if let Some(v) = self.extent {
+            my_size += ::protobuf::rt::value_size(5, v, ::protobuf::wire_format::WireTypeVarint);
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(v) = self.version {
+            os.write_uint32(15, v)?;
+        };
+        if let Some(v) = self.name.as_ref() {
+            os.write_string(1, &v)?;
+        };
+        for v in &self.features {
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        };
+        for v in &self.keys {
+            os.write_string(3, &v)?;
+        };
+        for v in &self.values {
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        };
+        if let Some(v) = self.extent {
+            os.write_uint32(5, v)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        ::protobuf::MessageStatic::descriptor_static(None::<Self>)
+    }
+}
+
+impl ::protobuf::MessageStatic for Tile_Layer {
+    fn new() -> Tile_Layer {
+        Tile_Layer::new()
+    }
+}
+
+impl ::protobuf::Clear for Tile_Layer {
+    fn clear(&mut self) {
+        self.clear_version();
+        self.clear_name();
+        self.clear_features();
+        self.clear_keys();
+        self.clear_values();
+        self.clear_extent();
+        self.unknown_fields.clear();
+    }
+}
+
+#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+pub enum Tile_GeomType {
+    UNKNOWN = 0,
+    POINT = 1,
+    LINESTRING = 2,
+    POLYGON = 3,
+}
+
+impl ::protobuf::ProtobufEnum for Tile_GeomType {
+    fn value(&self) -> i32 {
+        *self as i32
+    }
+
+    fn from_i32(value: i32) -> ::std::option::Option<Tile_GeomType> {
+        match value {
+            0 => ::std::option::Option::Some(Tile_GeomType::UNKNOWN),
+            1 => ::std::option::Option::Some(Tile_GeomType::POINT),
+            2 => ::std::option::Option::Some(Tile_GeomType::LINESTRING),
+            3 => ::std::option::Option::Some(Tile_GeomType::POLYGON),
+            _ => ::std::option::Option::None
+        }
+    }
+
+    fn values() -> &'static [Self] {
+        static values: &'static [Tile_GeomType] = &[
+            Tile_GeomType::UNKNOWN,
+            Tile_GeomType::POINT,
+            Tile_GeomType::LINESTRING,
+            Tile_GeomType::POLYGON,
+        ];
+        values
+    }
+}
+
+impl ::std::marker::Copy for Tile_GeomType {
+}

--- a/src/mvt/screen.rs
+++ b/src/mvt/screen.rs
@@ -1,0 +1,38 @@
+//! Grid and Geometry types in screen coordinates
+
+#[derive(Debug, PartialEq)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl Point {
+    pub fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MultiPoint {
+    pub points: Vec<Point>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct LineString {
+    pub points: Vec<Point>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MultiLineString {
+    pub lines: Vec<LineString>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Polygon {
+    pub rings: Vec<LineString>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MultiPolygon {
+    pub polygons: Vec<Polygon>,
+}

--- a/web/main.js
+++ b/web/main.js
@@ -37,7 +37,7 @@ window.onload = () => {
             paint: {
                 'circle-radius': {
                     base: 1.75,
-                    stops: [[12, 2], [22, 180]]
+                    stops: [[14, 2], [22, 25]]
                 },
             }
         });

--- a/web/main.js
+++ b/web/main.js
@@ -24,4 +24,22 @@ window.onload = () => {
         center: [-96, 37.8],
         zoom: 3
     });
+
+    window.vue.map.on('load', () => {
+        window.vue.map.addLayer({
+            id: 'hecate-data',
+            type: 'circle',
+            source: {
+                type: 'vector',
+                tiles: ['http://localhost:8000/api/tiles/{z}/{x}/{y}']
+            },
+            'source-layer': 'data',
+            paint: {
+                'circle-radius': {
+                    base: 1.75,
+                    stops: [[12, 2], [22, 180]]
+                },
+            }
+        });
+    });
 }


### PR DESCRIPTION
This PR queries postgis for vector tiles in a given tile, obtains the raw postgis geometry, converts it to a vector tile and then serves it.

*New Endpoint*
```
localhost:8000/api/tiles/z/x/y
```

A map containing the vector tile can be viewed via:
```
localhost:8000/admin
```