### PR TITLE
JSON Schema Validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 reqwest = "0.8.4"
 
 [dependencies]
-valico = "1"
+valico = "2.0"
 rand = "0.4"
 tempdir = "0.3"
 postgis = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 reqwest = "0.8.4"
 
 [dependencies]
+valico = "1"
 rand = "0.4"
 tempdir = "0.3"
 postgis = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ A custom property validation file can be specified using the schema flag.
 cargo run -- --schema <PATH-TO-SCHEMA>.json
 ```
 
-Note hecate currently supports the JSON Schema draft-05. Once draft-06/07 support lands in
+Note hecate currently supports the JSON Schema draft-04. Once draft-06/07 support lands in
 [valico](https://github.com/rustless/valico) we can support newer versions of the spec.
 
 ## API

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ OpenStreetMap Inspired Data Storage Backend Focused on Performance and GeoJSON I
 3. [Build Environment](#build-environment)
 3. [Docker File](#docker-file-coverage-tests)
 4. [Feature Format](#feature-format)
-5. [API](#api)
+5. [Server](#server)
+    - [Database Connection](#database)
+    - [JSON Validation](#json-validation)
+6. [API](#api)
     - [User Options](#user-options)
     - [Admin Interface](#admin-interface)
     - [Vector Tiles](#vector-tiles)
@@ -203,6 +206,46 @@ A feature being uploaded for deletion must have the `action: delete` as well as 
 Note the `properties` and `geometry` attributes must still be included. They can be set to `null` or be their previous value. They will be ignored.
 
 ### Samples
+
+## Server
+
+This section of the guide goes over various options on has when launching the server
+
+Hecate can be launched with default options with
+
+```
+cargo run
+```
+
+### Database
+
+By default hecate will attempt to connect to `postgres@localhost:5432/hecate`.
+
+Note that only postgres/postgis backed databases are currently supported.
+
+This database should be created prior to launching hecate. For instructions on setting up the database
+see the [Build Environment](#build-environment) section of this doc.
+
+A custom database name, postgres user or port can be specified using the database flag.
+
+```
+cargo run -- --database "<USER>:<PASSWORD>@<HOST>/<DATABASE>"
+
+cargo run -- --database "<USER>@<HOST>/<DATABASE>"
+```
+
+### JSON Validation
+
+By default hecate will allow any properties on a given GeoJSON feature, including nestled arrays, maps, etc.
+
+A custom property validation file can be specified using the schema flag.
+
+```
+cargo run -- --schema <PATH-TO-SCHEMA>.json
+```
+
+Note hecate currently supports the JSON Schema draft-05. Once draft-06/07 support lands in
+[valico](https://github.com/rustless/valico) we can support newer versions of the spec.
 
 ## API
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -9,3 +9,10 @@ args:
         value_name: DATABASE
         help: Specify an alternate database in format USER@HOST:PORT/DATABASE
         takes_value: true
+
+    - schema:
+        short: s
+        long: schema
+        value_name: SCHEMA
+        help: Specify a JSON Validation Schema for data in the hecate database
+        takes_value: true

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -99,8 +99,16 @@ pub fn get_action(feat: &geojson::Feature) -> Result<Action, FeatureError> {
     }
 }
 
-pub fn action(trans: &postgres::transaction::Transaction, feat: &geojson::Feature, delta: &Option<i64>) -> Result<Response, FeatureError> {
+pub fn action(trans: &postgres::transaction::Transaction, schema: &Option<serde_json::value::Value>, feat: &geojson::Feature, delta: &Option<i64>) -> Result<Response, FeatureError> {
     let action = get_action(&feat)?;
+
+    let valid: bool = match schema {
+        &Some(ref schema) => {
+            println!("{:?}", schema);
+            true
+        },
+        &None => true
+    };
 
     let res = match action {
         Action::Create => create(&trans, &feat, &delta)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn bounds_get(conn: DbConn, bounds: String) -> Result<Stream<std::fs::File>, sta
     let dir = TempDir::new(&*&format!("bounds_get_{}", rand::random::<i32>().to_string())).unwrap();
     let file_path = dir.path().join("bounds.geojson");
 
-    { 
+    {
         let mut f = File::create(&file_path).unwrap();
 
         while let Some(row) = rows.next().unwrap() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 
 extern crate hecate;
 extern crate rand;
+extern crate valico;
 extern crate rocket;
 extern crate rocket_contrib;
 #[macro_use] extern crate clap;
@@ -35,6 +36,7 @@ use clap::App;
 use geojson::GeoJson;
 use hecate::{feature, user, bounds, delta, xml, mvt};
 use fallible_iterator::FallibleIterator;
+use std::io::Read;
 
 pub type PostgresPool = Pool<PostgresConnectionManager>;
 pub type PostgresPooledConnection = PooledConnection<PostgresConnectionManager>;
@@ -66,10 +68,25 @@ fn main() {
 
     let database = matched.value_of("database").unwrap_or("postgres@localhost:5432/hecate");
 
+    let validation:Option<serde_json::value::Value> = match matched.value_of("schema") {
+        Some(schema_path) => {
+            let mut schema_file = File::open(&Path::new(schema_path)).unwrap();
+            let mut schema_str = String::new();
+
+            schema_file.read_to_string(&mut schema_str).unwrap();
+
+            let schema_json: serde_json::value::Value = serde_json::from_str(&schema_str).unwrap();
+
+            Some(schema_json)
+        },
+        None => None
+    };
+
     env_logger::init();
 
     rocket::ignite()
         .manage(init_pool(&database))
+        .manage(validation)
         .mount("/", routes![
             index
         ])
@@ -295,7 +312,7 @@ fn features_get(conn: DbConn, map: Map) -> Result<String, status::Custom<String>
 }
 
 #[post("/data/features", format="application/json", data="<body>")]
-fn features_action(auth: user::Auth, conn: DbConn, body: String) -> Result<Json, status::Custom<String>> {
+fn features_action(auth: user::Auth, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<String>> {
     let uid = match user::auth(&conn.0, auth) {
         Some(uid) => uid,
         _ => { return Err(status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"))); }
@@ -334,16 +351,14 @@ fn features_action(auth: user::Auth, conn: DbConn, body: String) -> Result<Json,
     };
 
     for feat in &mut fc.features {
-        match feature::action(&trans, &feat, &None) {
+        match feature::action(&trans, &schema.inner(), &feat, &None) {
             Err(err) => {
                 trans.set_rollback();
                 trans.finish().unwrap();
                 return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string()));
             },
             Ok(res) => {
-                if res.old == None {
-                    feat.id = Some(json!(res.new));
-                }
+                if res.old == None { feat.id = Some(json!(res.new)); }
             }
         }
     }
@@ -467,7 +482,7 @@ fn xml_changeset_modify(auth: user::Auth, conn: DbConn, delta_id: i64, body: Str
 }
 
 #[post("/0.6/changeset/<delta_id>/upload", data="<body>")]
-fn xml_changeset_upload(auth: user::Auth, conn: DbConn, delta_id: i64, body: String) -> Result<status::Custom<String>, Response<'static>> {
+fn xml_changeset_upload(auth: user::Auth, conn: DbConn, schema: State<Option<serde_json::value::Value>>, delta_id: i64, body: String) -> Result<status::Custom<String>, Response<'static>> {
     let uid = match user::auth(&conn.0, auth) {
         Some(uid) => uid,
         _ => { return Ok(status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"))); }
@@ -497,7 +512,7 @@ fn xml_changeset_upload(auth: user::Auth, conn: DbConn, delta_id: i64, body: Str
     let mut ids: HashMap<i64, feature::Response> = HashMap::new();
 
     for feat in &mut fc.features {
-        let feat_res = match feature::action(&trans, &feat, &Some(delta_id)) {
+        let feat_res = match feature::action(&trans, &schema.inner(), &feat, &Some(delta_id)) {
             Err(err) => {
                 trans.set_rollback();
                 trans.finish().unwrap();
@@ -595,7 +610,7 @@ fn xml_user() -> String {
 }
 
 #[post("/data/feature", format="application/json", data="<body>")]
-fn feature_action(auth: user::Auth, conn: DbConn, body: String) -> Result<Json, status::Custom<String>> {
+fn feature_action(auth: user::Auth, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<String>> {
     let uid = match user::auth(&conn.0, auth) {
         Some(uid) => uid,
         _ => { return Err(status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"))); }
@@ -633,7 +648,7 @@ fn feature_action(auth: user::Auth, conn: DbConn, body: String) -> Result<Json, 
         }
     };
 
-    match feature::action(&trans, &feat, &None) {
+    match feature::action(&trans, schema.inner(), &feat, &None) {
         Ok(res) => { feat.id = Some(json!(res.new)) },
         Err(err) => {
             trans.set_rollback();

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -145,9 +145,7 @@ pub fn destroy_token(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnec
         DELETE FROM users_tokens
             WHERE token = $1;
     ", &[ &token ]) {
-        Ok(res) => {
-            Ok(true)
-        },
+        Ok(_) => Ok(true),
         Err(_) => Err(UserError::NotFound)
     }
 }


### PR DESCRIPTION
Validate properties of all features created or modified via the API, failing if the props don't match the JSON schema.

**Example Usage**
```
hecate --schema buildings.json
```

See http://json-schema.org/ for documentation on writing a schema.
