### PR TITLE
Tile Cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN git clone http://github.com/SimonKagstrom/kcov.git && \
     make install
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-    && ~/.cargo/bin/rustup install nightly \
-    && ~/.cargo/bin/rustup default nightly \
+    && ~/.cargo/bin/rustup install nightly-2018-01-12 \
+    && ~/.cargo/bin/rustup default nightly-2018-01-12 \
     && ~/.cargo/bin/cargo install cargo-kcov
 
 RUN echo "local all all trust " > /etc/postgresql/9.6/main/pg_hba.conf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN git clone http://github.com/SimonKagstrom/kcov.git && \
     make install
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
-    && ~/.cargo/bin/rustup install nightly-2018-01-12 \
-    && ~/.cargo/bin/rustup default nightly-2018-01-12 \
+    && ~/.cargo/bin/rustup install nightly-2018-01-13 \
+    && ~/.cargo/bin/rustup default nightly-2018-01-13 \
     && ~/.cargo/bin/cargo install cargo-kcov
 
 RUN echo "local all all trust " > /etc/postgresql/9.6/main/pg_hba.conf \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h1 align='center'>Hecate</h1>
 
+<p align="center">
+  <a href="https://circleci.com/gh/ingalls/hecate/tree/master"><img src="https://circleci.com/gh/ingalls/hecate/tree/master.svg?style=shield"/></a>
+</p>
+
 ## Brief
 
 OpenStreetMap Inspired Data Storage Backend Focused on Performance and GeoJSON Interchange

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ source ~/.bashrc        # Most Linux Distros, some OSX
 source ~/.bash_profile  # Most OSX, some Linux Distros
 ```
 
-- Install the `nightly` build of rust, `Rocket`, the web-framework relies on some advanced compiler options not yet included in the default build.
+- Install the `nightly-2018-01-12` build of rust, `Rocket`, the web-framework relies on some advanced compiler options not yet included in the default build.
 
 ```bash
-rustup install nightly
-rustup default nightly
+rustup install nightly-2018-01-12
+rustup default nightly-2018-01-12
 ```
 
 - Download and compile the project and all of it's libraries

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ source ~/.bashrc        # Most Linux Distros, some OSX
 source ~/.bash_profile  # Most OSX, some Linux Distros
 ```
 
-- Install the `nightly-2018-01-12` build of rust, `Rocket`, the web-framework relies on some advanced compiler options not yet included in the default build.
+- Install the `nightly-2018-01-13` build of rust, `Rocket`, the web-framework relies on some advanced compiler options not yet included in the default build.
 
 ```bash
-rustup install nightly-2018-01-12
-rustup default nightly-2018-01-12
+rustup install nightly-2018-01-13
+rustup default nightly-2018-01-13
 ```
 
 - Download and compile the project and all of it's libraries

--- a/src/mvt/encoder.rs
+++ b/src/mvt/encoder.rs
@@ -7,6 +7,7 @@ use mvt::proto;
 
 pub trait Encode {
     fn to_writer(&self, out: &mut Write) -> Result<(), ProtobufError>;
+    fn to_bytes(&self) -> Result<Vec<u8>, ProtobufError>;
 }
 
 pub trait Decode {
@@ -18,6 +19,13 @@ impl Encode for proto::Tile {
         let mut os = CodedOutputStream::new(&mut out);
         let _ = self.write_to(&mut os);
         os.flush()
+    }
+
+    fn to_bytes(&self) -> Result<Vec<u8>, ProtobufError> {
+        let mut bytes = Vec::<u8>::new();
+        CodedOutputStream::vec(&mut bytes);
+
+        Ok(bytes)
     }
 }
 

--- a/src/mvt/encoder.rs
+++ b/src/mvt/encoder.rs
@@ -12,6 +12,7 @@ pub trait Encode {
 
 pub trait Decode {
     fn from_reader(input: &mut Read) -> Result<Self, ProtobufError> where Self: Sized;
+    fn from_bytes(bytes: &Vec<u8>) -> Result<Self, ProtobufError> where Self: Sized;
 }
 
 impl Encode for proto::Tile {
@@ -36,5 +37,9 @@ impl Decode for proto::Tile {
     fn from_reader(input: &mut Read) -> Result<Self, ProtobufError> {
         let mut reader = BufReader::new(input);
         protobuf::parse_from_reader(&mut reader)
+    }
+
+    fn from_bytes(bytes: &Vec<u8>) -> Result<Self, ProtobufError> {
+        protobuf::parse_from_bytes(bytes)
     }
 }

--- a/src/mvt/encoder.rs
+++ b/src/mvt/encoder.rs
@@ -23,7 +23,10 @@ impl Encode for proto::Tile {
 
     fn to_bytes(&self) -> Result<Vec<u8>, ProtobufError> {
         let mut bytes = Vec::<u8>::new();
-        CodedOutputStream::vec(&mut bytes);
+        {
+            let mut os = CodedOutputStream::vec(&mut bytes);
+            let _ = self.write_to(&mut os);
+        }
 
         Ok(bytes)
     }

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -46,7 +46,7 @@ pub fn db_get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
         FROM tiles
         WHERE
             ref = $1
-            AND NOW() > created + INVERVAL '4 hours'
+            AND NOW() > created + INTERVAL '4 hours'
     ", &[&coord]) {
         Ok(rows) => rows,
         Err(err) => match err.as_db() {

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -51,12 +51,12 @@ pub fn db_get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     ", &[&z, &x, &y]) {
         Ok(rows) => rows,
         Err(_) => { return Err(MVTError::DB); }
-};
+    };
 
-if rows.len() == 0 { return Ok(None); }
+    if rows.len() == 0 { return Ok(None); }
 
-Ok(None)
-    }
+    Ok(None)
+}
 
 pub fn db_create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: &u8, x: &u32, y: &u32) -> Result<proto::Tile, MVTError> {
     let grid = Grid::web_mercator();
@@ -106,12 +106,14 @@ pub fn db_cache(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionM
 }
 
 pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32) -> Result<proto::Tile, MVTError> {
-    match db_get(&conn, i64::from(z), i64::from(x), i64::from(y))? {
+    match db_get(&conn, z as i64, x as i64, y as i64)? {
         Some(tile) => { return Ok(tile); }
         _ => ()
     };
 
     let tile = db_create(&conn, &z, &x, &y)?;
+
+    db_cache(&conn, z as i64, x as i64, y as i64, &tile)?;
 
     Ok(tile)
 }

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -97,7 +97,7 @@ pub fn db_create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnection
 
 pub fn db_cache(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: i64, x: i64, y: i64, tile: &proto::Tile) -> Result<(), MVTError> {
     match conn.query("
-        INSERT INTO tiles (z, x, y, tiles)
+        INSERT INTO tiles (z, x, y, tile)
             VALUES ($1, $2, $3, $4)
     ", &[&z, &x, &y, &tile.to_bytes().unwrap()]) {
         Err(_) => Err(MVTError::DB),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -6,9 +6,7 @@ CREATE EXTENSION IF NOT EXISTS hstore;
 
 DROP TABLE IF EXISTS tiles;
 CREATE TABLE tiles (
-    z           BIGINT UNIQUE,
-    x           BIGINT UNIQUE,
-    y           BIGINT UNIQUE,
+    ref         TEXT UNIQUE,
     tile        BYTEA
 );
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -4,6 +4,14 @@ CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS hstore;
 
+DROP TABLE IF EXISTS tiles;
+CREATE TABLE tiles (
+    z           BIGINT,
+    x           BIGINT,
+    y           BIGINT,
+    tile        BYTEA
+);
+
 DROP TABLE IF EXISTS bounds;
 CREATE TABLE bounds (
     id          BIGSERIAL,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -6,9 +6,9 @@ CREATE EXTENSION IF NOT EXISTS hstore;
 
 DROP TABLE IF EXISTS tiles;
 CREATE TABLE tiles (
-    z           BIGINT,
-    x           BIGINT,
-    y           BIGINT,
+    z           BIGINT UNIQUE,
+    x           BIGINT UNIQUE,
+    y           BIGINT UNIQUE,
     tile        BYTEA
 );
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -6,6 +6,7 @@ CREATE EXTENSION IF NOT EXISTS hstore;
 
 DROP TABLE IF EXISTS tiles;
 CREATE TABLE tiles (
+    created     TIMESTAMP,
     ref         TEXT UNIQUE,
     tile        BYTEA
 );

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -60,6 +60,7 @@ mod test {
             assert_eq!(tile_ref, String::from("1/2/3"));
 
             let tile: Vec<u8> = res.get(0).get(1);
+
             assert_eq!(tile.len(), 10);
         }
 
@@ -70,7 +71,7 @@ mod test {
             let mut body: Vec<u8> = Vec::new();
             resp.read_to_end(&mut body).unwrap();
 
-            assert_eq!(body.len(), 10);
+            assert_eq!(body.len(), 13);
             assert!(resp.status().is_success());
         }
 

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -1,0 +1,79 @@
+extern crate reqwest;
+extern crate postgres;
+extern crate hecate;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+
+    #[test]
+    fn tiles() {
+        { // Reset Database:
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("DROP DATABASE IF EXISTS hecate;", &[]).unwrap();
+            conn.execute("CREATE DATABASE hecate;", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+
+        { //Request a tile via API
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/2/3").send().unwrap();
+
+            let mut body: Vec<u8> = Vec::new();
+            resp.read_to_end(&mut body).unwrap();
+
+            assert_eq!(body.len(), 13);
+            assert!(resp.status().is_success());
+        }
+
+        { //Ensure Tile was places in DB tilecache
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+            let res = conn.query("SELECT ref, tile FROM tiles", &[]).unwrap();
+
+            assert_eq!(res.len(), 1);
+
+            let tile_ref: String = res.get(0).get(0);
+            assert_eq!(tile_ref, String::from("1/2/3"));
+
+            let tile: Vec<u8> = res.get(0).get(1);
+            assert_eq!(tile.len(), 10);
+        }
+
+        { //Request a tile via API
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/2/3").send().unwrap();
+
+            let mut body: Vec<u8> = Vec::new();
+            resp.read_to_end(&mut body).unwrap();
+
+            assert_eq!(body.len(), 13);
+            assert!(resp.status().is_success());
+        }
+
+        server.kill().unwrap();
+    }
+}

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -70,7 +70,7 @@ mod test {
             let mut body: Vec<u8> = Vec::new();
             resp.read_to_end(&mut body).unwrap();
 
-            assert_eq!(body.len(), 13);
+            assert_eq!(body.len(), 10);
             assert!(resp.status().is_success());
         }
 

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,6 @@
 
         <title>Hecate UI | Mapbox</title>
 
-        <link rel='stylesheet' href='./main.css' />
         <link href='https://api.mapbox.com/mapbox-assembly/v0.19.0/assembly.min.css' rel='stylesheet'>
         <script async defer src='https://api.mapbox.com/mapbox-assembly/v0.19.0/assembly.js'></script>
         <script async defer src='https://cdnjs.cloudflare.com/ajax/libs/Turf.js/5.1.5/turf.js'></script>


### PR DESCRIPTION
Tile Serving is currently very slow due to each tile being calculated from scratch at every request.

This PR implements a Tile Cache which will serve precomputed tiles if they exist in the cache before falling back to a re-render.

Cleaning the cache is currently a manual process but the end goal will be:
- Port tile-cover to rust
- On each delta calculate covered tiles and invalidate affected