### PR TITLE
Invalidate Geoms with TileCover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spade 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "geojson"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +427,7 @@ dependencies = [
  "rocket_contrib 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tilecover 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "valico 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1465,6 +1477,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tilecover"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "geo 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +1818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum geo 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3f587a8e7ce8b1633c44a4a24bbeb6dad09f1db740ec335a072e7a1eeb6de8"
+"checksum geo 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3addba4cc2a1afc28587d6816c31626db5c906eb2c4924c3546f76bbf22329a3"
 "checksum geojson 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3484ce9e9560be7e5dffe685dfe2cf2dbf785fc3dac2f193fb42c56a797c3d1"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
@@ -1917,6 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum tilecover 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "718463b68d9fde6151aa55089dbc19b6e09e6ff5b75f948fea21f3f0984d08c5"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "52b4e32d8edbf29501aabb3570f027c6ceb00ccef6538f4bddba0200503e74e8"
 "checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ r2d2 = "0.8.1"
 r2d2_postgres = "0.14.0"
 env_logger = "0.5"
 fallible-iterator = "0.1.x"
+tilecover = "0.4.1"
 
 [dependencies.postgres]
 version = "0.15.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,16 +39,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
-RUN git clone http://github.com/SimonKagstrom/kcov.git && \
-    cd kcov && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-01-13 \
-    && ~/.cargo/bin/cargo install cargo-kcov
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-01-13
 
 RUN echo "local all all trust " > /etc/postgresql/9.6/main/pg_hba.conf \
     && echo "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.6/main/pg_hba.conf \

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -4,6 +4,8 @@ extern crate geojson;
 extern crate postgres;
 extern crate serde_json;
 extern crate valico;
+extern crate tilecover;
+extern crate geo;
 
 #[derive(PartialEq, Debug)]
 pub enum FeatureError {
@@ -57,6 +59,12 @@ impl FeatureError {
             FeatureError::InvalidFeature => String::from( "Invalid Feature")
         }
     }
+}
+
+pub fn invalidate(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, feat: geo::Geometry<f64>) -> Result<bool, FeatureError> {
+    //tilecover::tiles(
+
+    Ok(true)
 }
 
 pub fn get_version(feat: &geojson::Feature) -> Result<i64, FeatureError> {

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -1,7 +1,5 @@
 extern crate postgis;
 extern crate protobuf;
-extern crate geo;
-extern crate tilecover;
 
 use r2d2; 
 use r2d2_postgres;
@@ -40,12 +38,6 @@ impl MVTError {
 
         }
     }
-}
-
-pub fn invalidate(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, feat: &geo::Geometry<f64>) -> Result<bool, MVTError> {
-    //tilecover::tiles(
-
-    Ok(true)
 }
 
 pub fn db_get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, coord: String) -> Result<Option<proto::Tile>, MVTError> {

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -1,5 +1,7 @@
 extern crate postgis;
 extern crate protobuf;
+extern crate geo;
+extern crate tilecover;
 
 use r2d2; 
 use r2d2_postgres;
@@ -40,6 +42,12 @@ impl MVTError {
     }
 }
 
+pub fn invalidate(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, feat: &geo::Geometry<f64>) -> Result<bool, MVTError> {
+    //tilecover::tiles(
+
+    Ok(true)
+}
+
 pub fn db_get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, coord: String) -> Result<Option<proto::Tile>, MVTError> {
     let rows = match conn.query("
         SELECT tile
@@ -71,8 +79,11 @@ pub fn db_create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnection
     let mut layer = Layer::new("data");
 
     let mut limit: Option<i64> = None;
-    if *z < 10 { limit = Some(10) }
-    else if *z < 14 { limit = Some(100) }
+
+    if *z < 8 { limit = Some(10) }
+    else if *z < 10 { limit = Some(100) }
+    else if *z < 12 { limit = Some(1000) }
+    else if *z < 14 { limit = Some(10000) }
 
     let rows = conn.query("
         SELECT

--- a/web/index.html
+++ b/web/index.html
@@ -151,7 +151,7 @@
                             <div v-for="delta in deltas" @click="delta_get(delta.id)" class="px12 py12 border-b bg-darken10-on-hover border--gray-light cursor-pointer wfull">
                                 <div class="clearfix">
                                     <div class="fl txt-bold" v-text="delta.username"></div>
-                                    <div class="fr txt-em" v-text="moment(delta.created).add(moment.tz(delta.created).utcOffset(), 'hours').fromNow()"></div>
+                                    <div class="fr txt-em" v-text="moment(delta.created).add(moment().utcOffset(), 'minutes').fromNow()"></div>
                                 </div>
                                 <span v-text="delta.props.message ? delta.props.message : '<No Delta Message>'"></span>
                                 <span class='bg-blue-faint color-blue inline-block px6 py3 my3 my3 txt-xs txt-bold round fr' v-text="delta.id"></span>


### PR DESCRIPTION
Invalidate tiles from calculated bounds of supported geom types (multi)(point/line), falling back to timeout value.

Ref: https://github.com/ingalls/Hecate/issues/25