### PR TITLE
Snazzy Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,49 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"name": "New Name", "style": "New Mapbox Style Object Here"}' \
-    'http://username:password@localhost:8000/api/style'
+    'http://username:password@localhost:8000/api/style/1'
+```
+
+---
+
+#### `POST` `/api/style/<id>/private`
+
+Update a public style and mark it as private.
+
+Note: Once a style is public other users may have cloned it. This will not
+affect cloned styles that were made when it was public.
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given style to download |
+
+*Example*
+
+```bash
+curl -X POST 'http://username:password@localhost:8000/api/style/1/private'
+```
+
+---
+
+#### `POST` `/api/style/<id>/public`
+
+Update a style to make it public.
+
+It will then appear to all users in the global styles list
+and other users will be able to download, clone, and use it
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given style to download |
+
+*Example*
+
+```bash
+curl -X POST 'http://username:password@localhost:8000/api/style/1/public'
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -276,6 +276,48 @@ View the Admin Interface in your browser by pointing to `127.0.0.1:8000/admin/in
 
 <h3 align='center'>Styles</h3>
 
+#### `GET` `/api/styles`
+
+Return an array containing a reference to every public style
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/styles'
+```
+
+---
+
+#### `GET` `/api/styles/<user id>`
+
+Return an array containing styles owned by a particular user.
+
+By default any request will only return the public styles for a given user.
+
+If an authenticated user requests their own styles, it will return their public and private styles.
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<user id>` | `REQUIRED` Numeric ID of the user to get styles from |
+
+*Example*
+
+Return only public styles of user 1
+
+```bash
+curl -X GET 'http://localhost:8000/api/styles/1'
+```
+
+User requesting their own styles will get public & private styles
+
+```bash
+curl -X GET 'http://username:password@localhost:8000/api/styles/1'
+```
+
+---
+
 #### `POST` `/api/style`
 
 Create a new private style attached to the authenticated user

--- a/README.md
+++ b/README.md
@@ -330,6 +330,28 @@ curl -X GET 'http://localhost:8000/api/style/1'
 
 ---
 
+#### `PATCH` `/api/style/<id>`
+
+Update a style - auth required - users can only update their own styles
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given style to download |
+
+*Example*
+
+```bash
+curl \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"name": "New Name", "style": "New Mapbox Style Object Here"}' \
+    'http://username:password@localhost:8000/api/style'
+```
+
+---
+
 <h3 align='center'>Schema</h3>
 
 #### `GET` `/api/schema`

--- a/README.md
+++ b/README.md
@@ -292,6 +292,25 @@ curl \
 
 ---
 
+#### `DELETE` `/api/style/<id>`
+
+Delete a particular style by id. Users must be authorized and 
+can only delete styles created by them.
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given style to delete |
+
+*Example*
+
+```bash
+curl -X DELETE 'http://localhost:8000/api/style/1'
+```
+
+---
+
 #### `GET` `/api/style/<id>`
 
 Get a particular style by id, public styles can be requested unauthenticated,
@@ -308,6 +327,8 @@ private styles can only be obtained by the corresponding user making the request
 ```bash
 curl -X GET 'http://localhost:8000/api/style/1'
 ```
+
+---
 
 <h3 align='center'>Schema</h3>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [User Options](#user-options)
     - [Admin Interface](#admin-interface)
     - [Schema](#schema)
+    - [Styles](#styles)
     - [Vector Tiles](#vector-tiles)
     - [Downloading via Boundaries](#downloading-via-boundaries)
     - [Downloading Individual Features](#downloading-individual-features)
@@ -273,8 +274,42 @@ View the Admin Interface in your browser by pointing to `127.0.0.1:8000/admin/in
 
 ---
 
-<h3 align='center'>Admin Interface</h3>
+<h3 align='center'>Styles</h3>
 
+#### `POST` `/api/style`
+
+Create a new private style attached to the authenticated user
+
+*Example*
+
+```bash
+curl \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"name": "Name of this particular style", "style": "Mapbox Style Object Here"}' \
+    'http://username:password@localhost:8000/api/style'
+```
+
+---
+
+#### `GET` `/api/style/<id>`
+
+Get a particular style by id, public styles can be requested unauthenticated,
+private styles can only be obtained by the corresponding user making the request.
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `<id>` | `REQUIRED` Numeric ID of a given style to download |
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/style/1'
+```
+
+<h3 align='center'>Schema</h3>
 
 #### `GET` `/api/schema`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>) {
             user_create,
             user_create_session,
             style_create,
+            style_get,
             delta,
             delta_list,
             delta_list_offset,
@@ -219,6 +220,16 @@ fn style_create(conn: DbConn, auth: user::Auth, style: String) -> Result<Json, s
 
     match style::create(&conn.0, &uid, &style) {
         Ok(created) => Ok(Json(json!(created))),
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+    }
+}
+
+#[get("/style/<id>")]
+fn style_get(conn: DbConn, auth: user::Auth, id: i64) -> Result<Json, status::Custom<String>> {
+    let uid: Option<i64> = user::auth(&conn.0, auth);
+
+    match style::get(&conn.0, &uid, &id) {
+        Ok(style) => Ok(Json(json!(style))),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>) {
             style_delete,
             style_get,
             style_list_public,
+            style_list_user,
             delta,
             delta_list,
             delta_list_offset,
@@ -297,6 +298,31 @@ fn style_list_public(conn: DbConn) -> Result<Json, status::Custom<String>> {
     match style::list_public(&conn.0) {
         Ok(styles) => Ok(Json(json!(styles))),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+    }
+}
+
+#[get("/styles/<user>")]
+fn style_list_user(conn: DbConn, auth: user::Auth, user: i64) -> Result<Json, status::Custom<String>> {
+    match user::auth(&conn.0, auth) {
+        Some(uid) => {
+            if uid == user {
+                match style::list_user(&conn.0, &user) {
+                    Ok(styles) => Ok(Json(json!(styles))),
+                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+                }
+            } else {
+                match style::list_user_public(&conn.0, &user) {
+                    Ok(styles) => Ok(Json(json!(styles))),
+                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+                }
+            }
+        },
+        _ => {
+            match style::list_user_public(&conn.0, &user) {
+                Ok(styles) => Ok(Json(json!(styles))),
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>) {
             user_create,
             user_create_session,
             style_create,
+            style_patch,
             style_delete,
             style_get,
             delta,
@@ -221,6 +222,19 @@ fn style_create(conn: DbConn, auth: user::Auth, style: String) -> Result<Json, s
 
     match style::create(&conn.0, &uid, &style) {
         Ok(created) => Ok(Json(json!(created))),
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+    }
+}
+
+#[patch("/style/<id>", format="application/json", data="<style>")]
+fn style_patch(conn: DbConn, auth: user::Auth, id: i64, style: String) -> Result<Json, status::Custom<String>> {
+    let uid = match user::auth(&conn.0, auth) {
+        Some(uid) => uid,
+        _ => { return Err(status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"))); }
+    };
+
+    match style::update(&conn.0, &uid, &id, &style) {
+        Ok(updated) => Ok(Json(json!(updated))),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>) {
             style_patch,
             style_delete,
             style_get,
+            style_list_public,
             delta,
             delta_list,
             delta_list_offset,
@@ -259,6 +260,14 @@ fn style_get(conn: DbConn, auth: user::Auth, id: i64) -> Result<Json, status::Cu
 
     match style::get(&conn.0, &uid, &id) {
         Ok(style) => Ok(Json(json!(style))),
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+    }
+}
+
+#[get("/styles")]
+fn style_list_public(conn: DbConn) -> Result<Json, status::Custom<String>> {
+    match style::list_public(&conn.0) {
+        Ok(styles) => Ok(Json(json!(styles))),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>) {
             user_create,
             user_create_session,
             style_create,
+            style_delete,
             style_get,
             delta,
             delta_list,
@@ -223,6 +224,20 @@ fn style_create(conn: DbConn, auth: user::Auth, style: String) -> Result<Json, s
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
     }
 }
+
+#[delete("/style/<id>")]
+fn style_delete(conn: DbConn, auth: user::Auth, id: i64) -> Result<Json, status::Custom<String>> {
+    let uid = match user::auth(&conn.0, auth) {
+        Some(uid) => uid,
+        _ => { return Err(status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"))); }
+    };
+
+    match style::delete(&conn.0, &uid, &id) {
+        Ok(created) => Ok(Json(json!(created))),
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+    }
+}
+
 
 #[get("/style/<id>")]
 fn style_get(conn: DbConn, auth: user::Auth, id: i64) -> Result<Json, status::Custom<String>> {

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -97,7 +97,8 @@ pub fn db_create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnection
         match props.as_object() {
             Some(props) => {
                 for (k, v) in props {
-                    feature.add_property(k, Value::String(serde_json::to_string(v)));
+                    println!("{} {}", k, v);
+                    //feature.add_property(k, Value::String(serde_json::to_string(v)));
                 }
             },
             None => ()

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -91,17 +91,16 @@ pub fn db_create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnection
         let id: i64 = row.get(0);
         let mut feature = Feature::new(row.get(2));
         feature.set_id(id as u64);
+
         feature.add_property("hecate:id", Value::String(id.to_string()));
 
         let props: serde_json::Value = row.get(1);
-        match props.as_object() {
-            Some(props) => {
-                for (k, v) in props {
-                    println!("{} {}", k, v);
-                    //feature.add_property(k, Value::String(serde_json::to_string(v)));
-                }
-            },
-            None => ()
+
+        let props = props.as_object().unwrap();
+
+        for (k, v) in props.iter() {
+            let v = serde_json::to_string(v).unwrap();
+            feature.add_property(k.clone(), Value::String(v));
         }
 
         layer.add_feature(feature);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -54,7 +54,7 @@ CREATE INDEX geo_idx ON geo(id);
 DROP TABLE IF EXISTS styles;
 CREATE TABLE styles (
     id          BIGSERIAL,
-    version     BIGINT,
+    name        TEXT,
     style       JSONB,
     uid         BIGINT,
     public      BOOLEAN

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -53,7 +53,7 @@ CREATE INDEX geo_idx ON geo(id);
 
 DROP TABLE IF EXISTS styles;
 CREATE TABLE styles (
-    id          BIGSERIAL
+    id          BIGSERIAL,
     version     BIGINT,
     style       JSONB,
     uid         BIGINT,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -51,6 +51,15 @@ CREATE TABLE geo (
 CREATE INDEX geo_gist ON geo USING GIST(geom);
 CREATE INDEX geo_idx ON geo(id);
 
+DROP TABLE IF EXISTS styles;
+CREATE TABLE styles (
+    id          BIGSERIAL
+    version     BIGINT,
+    style       JSONB,
+    uid         BIGINT,
+    public      BOOLEAN
+);
+
 DROP TABLE IF EXISTS deltas;
 CREATE TABLE deltas (
     id          BIGSERIAL,

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -24,7 +24,7 @@ pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
         INSERT into styles (name, style, uid, public)
             VALUES (
                 'New Style',
-                $1,
+                $1::TEXT::JSON,
                 $2,
                 false
             )

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1,0 +1,61 @@
+extern crate r2d2;
+extern crate r2d2_postgres;
+extern crate postgres;
+extern crate serde_json;
+
+#[derive(PartialEq, Debug)]
+pub enum StyleError {
+    NotFound,
+}
+
+impl StyleError {
+    pub fn to_string(&self) -> String {
+        match *self {
+            StyleError::NotFound => String::from("Style Not Found"),
+        }
+    }
+}
+
+/// Creates a new GL JS Style under a given user account
+/// By default styles are private and can only be accessed
+/// by a single user
+pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}
+
+pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}
+
+pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}
+
+pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}
+pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}
+
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+    conn.query("
+    ", &[]).unwrap();
+
+    Err(StyleError::NotFound)
+}

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -17,8 +17,8 @@ impl StyleError {
 }
 
 /// Creates a new GL JS Style under a given user account
-/// By default styles are private and can only be accessed
-/// by a single user
+///
+/// By default styles are private and can only be accessed by a single user
 pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64, style: &String) -> Result<bool, StyleError> {
     conn.query("
         INSERT into styles (name, style, uid, public)
@@ -33,9 +33,21 @@ pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     Ok(true)
 }
 
-pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
+/// Get the style by id, if the style is public, the user need not be logged in,
+/// if the style is private ensure the owner is the requester
+pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &Option<i64>, style_id: &i64) -> Result<bool, StyleError> {
     conn.query("
-    ", &[]).unwrap();
+        SELECT
+            style
+        FROM
+            styles
+        WHERE
+            id = $1
+            AND (
+                public IS true
+                OR uid = $2
+            )
+    ", &[&style_id, &uid]).unwrap();
 
     Err(StyleError::NotFound)
 }

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -19,41 +19,41 @@ impl StyleError {
 /// Creates a new GL JS Style under a given user account
 /// By default styles are private and can only be accessed
 /// by a single user
-pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64, style: &String) -> Result<bool, StyleError> {
+    conn.query("
+        INSERT into styles (name, style, uid, public)
+            VALUES (
+                'New Style',
+                $1,
+                $2,
+                false
+            )
+    ", &[&style, &uid]).unwrap();
+
+    Ok(true)
+}
+
+pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
     ", &[]).unwrap();
 
     Err(StyleError::NotFound)
 }
 
-pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
     ", &[]).unwrap();
 
     Err(StyleError::NotFound)
 }
 
-pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
     ", &[]).unwrap();
 
     Err(StyleError::NotFound)
 }
-
-pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
-    conn.query("
-    ", &[]).unwrap();
-
-    Err(StyleError::NotFound)
-}
-pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
-    conn.query("
-    ", &[]).unwrap();
-
-    Err(StyleError::NotFound)
-}
-
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Json, StyleError> {
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
     ", &[]).unwrap();
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -81,12 +81,30 @@ pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     Err(StyleError::NotFound)
 }
 
-pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
-    conn.query("
-    ", &[]).unwrap();
-
-    Err(StyleError::NotFound)
+pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64, style_id: &i64) -> Result<bool, StyleError> {
+    match conn.execute("
+        DELETE
+            FROM styles
+            WHERE
+                uid = $1
+                AND id = $2
+    ", &[&uid, &style_id]) {
+        Ok(deleted) => {
+            if deleted == 0 {
+                Err(StyleError::NotFound)
+            } else {
+                Ok(true)
+            }
+        },
+        Err(err) => {
+            match err.as_db() {
+                Some(_e) =>  Err(StyleError::NotFound),
+                _ => Err(StyleError::NotFound)
+            } 
+        }
+    }
 }
+
 pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
     ", &[]).unwrap();

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -141,7 +141,7 @@ pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
 pub fn list_public(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Value, StyleError> {
     match conn.query("
         SELECT
-            JSON_Agg(row_to_json(t))
+            COALESCE(JSON_Agg(row_to_json(t)), '[]'::JSON)
         FROM (
             SELECT
                 *

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -81,6 +81,7 @@ pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     Err(StyleError::NotFound)
 }
 
+///Allow the owner of a given style to delete it
 pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64, style_id: &i64) -> Result<bool, StyleError> {
     match conn.execute("
         DELETE
@@ -105,8 +106,13 @@ pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
+pub fn public_list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, StyleError> {
     conn.query("
+        SELECT
+            id,
+            name
+        FROM
+            styles
     ", &[]).unwrap();
 
     Err(StyleError::NotFound)

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -78,8 +78,8 @@ pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     match conn.execute("
         UPDATE styles
             SET
-                name = COALESCE($3::JSON->>'name', name)
-                style = COALESCE($3::JSON->>'style', style)
+                name = COALESCE($3::TEXT::JSON->>'name', name),
+                style = COALESCE($3::TEXT::JSONB->'style', style)
             WHERE
                 id = $1
                 AND uid = $2
@@ -92,6 +92,7 @@ pub fn update(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
             }
         },
         Err(err) => {
+            println!("ERROR: {}", err);
             match err.as_db() {
                 Some(_e) =>  Err(StyleError::NotFound),
                 _ => Err(StyleError::NotFound)

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -168,7 +168,10 @@ pub fn list_public(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnecti
             COALESCE(JSON_Agg(row_to_json(t)), '[]'::JSON)
         FROM (
             SELECT
-                *
+                id,
+                name,
+                public,
+                uid
             FROM
                 styles
             WHERE

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -165,12 +165,22 @@ impl<'a, 'r> FromRequest<'a, 'r> for Auth {
 
         let keys: Vec<_> = request.headers().get("Authorization").collect();
 
-        if keys.len() != 1 || keys[0].len() < 7 { return Outcome::Failure((Status::Unauthorized, ())); }
+        if keys.len() != 1 || keys[0].len() < 7 {
+            return Outcome::Success(Auth {
+                token: None,
+                basic: None
+            });
+        }
 
         let mut authtype = String::from(keys[0]);
         let auth = authtype.split_off(6);
 
-        if authtype != "Basic " { return Outcome::Failure((Status::Unauthorized, ())); }
+        if authtype != "Basic " {
+            return Outcome::Success(Auth {
+                token: None,
+                basic: None
+            });
+        }
 
         match base64::decode(&auth) {
             Ok(decoded) => match String::from_utf8(decoded) {

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -105,6 +105,16 @@ mod test {
             assert_eq!(resp.text().unwrap(), r#"true"#);
             assert!(resp.status().is_success());
         }
+        
+        { //Delete Style - Doesnt Exist
+            let client = reqwest::Client::new();
+            let mut resp = client.delete("http://localhost:8000/api/style/100")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"Style Not Found"#);
+            assert!(resp.status().is_client_error());
+        }
 
         server.kill().unwrap();
     }

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -177,6 +177,54 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
+        { //Create Style 1 For List Tests
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/style")
+                .body(r#"{
+                    "name": "Style 1",
+                    "style": "I am a style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Style 2 For List Tests
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/style")
+                .body(r#"{
+                    "name": "Style 2",
+                    "style": "I am a style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Style 3 For List Tests
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/style")
+                .body(r#"{
+                    "name": "Style 2",
+                    "style": "I am a style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -84,7 +84,7 @@ mod test {
                 .send()
                 .unwrap();
             assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Awesome Style","style":"I am a style"}"#);
-            assert!(resp.status().is_client_error());
+            assert!(resp.status().is_success());
         }
 
         server.kill().unwrap();

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -49,12 +49,6 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        { //Create Username (ingalls-other)
-            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls-other&password=yeaheh&email=fake@example.com").unwrap();
-            assert_eq!(resp.text().unwrap(), "true");
-            assert!(resp.status().is_success());
-        }
-
         { //Create Style
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/style")
@@ -228,6 +222,12 @@ mod test {
 
         { //Get List of Public Styles - Style 1 should now appear, since it is now public
             let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
+            assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1}]"#);
+            assert!(resp.status().is_success());
+        }
+
+        { //Get User List of Public Styles - Style 1 should now appear, since it is now public
+            let mut resp = reqwest::get("http://localhost:8000/api/styles/1").unwrap();
             assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1}]"#);
             assert!(resp.status().is_success());
         }

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -97,6 +97,57 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
+        { //Update Style Name - Auth: ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.patch("http://localhost:8000/api/style/1")
+                .body(r#"{
+                    "name": "Modified Awesome Style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Get Style - Authed: ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/style/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Modified Awesome Style","style":"I am a style"}"#);
+            assert!(resp.status().is_success());
+        }
+
+
+        { //Update Style Style - Auth: ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.patch("http://localhost:8000/api/style/1")
+                .body(r#"{
+                    "style": "I am a modified style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Get Style - Authed: ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/style/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Modified Awesome Style","style":"I am a modified style"}"#);
+            assert!(resp.status().is_success());
+        }
+
         { //Delete Style - No Auth
             let client = reqwest::Client::new();
             let mut resp = client.delete("http://localhost:8000/api/style/1")

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -1,0 +1,91 @@
+extern crate reqwest;
+extern crate postgres;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+
+    #[test]
+    fn styles() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+
+        { //Create Username (ingalls)
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls&password=yeaheh&email=ingalls@protonmail.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Username (ingalls-other)
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls-other&password=yeaheh&email=fake@example.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Style
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/style")
+                .body(r#"{
+                    "style": "I am a style"
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Get Style - No Auth
+            let mut resp = reqwest::get("http://localhost:8000/api/style/1").unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Get Ingalls - ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/style/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert!(resp.status().is_client_error());
+        }
+
+        server.kill().unwrap();
+    }
+}

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -59,6 +59,7 @@ mod test {
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/style")
                 .body(r#"{
+                    "name": "Awesome Style",
                     "style": "I am a style"
                 }"#)
                 .basic_auth("ingalls", Some("yeaheh"))
@@ -82,7 +83,7 @@ mod test {
                 .basic_auth("ingalls", Some("yeaheh"))
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Awesome Style","style":"I am a style"}"#);
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -87,6 +87,22 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Delete Style - No Auth
+            let mut resp = reqwest::delete("http://localhost:8000/api/style/1").unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Delete Ingalls - ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.delete("http://localhost:8000/api/style/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Awesome Style","style":"I am a style"}"#);
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -88,7 +88,10 @@ mod test {
         }
 
         { //Delete Style - No Auth
-            let mut resp = reqwest::delete("http://localhost:8000/api/style/1").unwrap();
+            let client = reqwest::Client::new();
+            let mut resp = client.delete("http://localhost:8000/api/style/1")
+                .send()
+                .unwrap();
             assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
             assert!(resp.status().is_client_error());
         }
@@ -99,7 +102,7 @@ mod test {
                 .basic_auth("ingalls", Some("yeaheh"))
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Awesome Style","style":"I am a style"}"#);
+            assert_eq!(resp.text().unwrap(), r#"true"#);
             assert!(resp.status().is_success());
         }
 

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -77,7 +77,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { //Get Ingalls - ingalls
+        { //Get Style - Authed: ingalls
             let client = reqwest::Client::new();
             let mut resp = client.get("http://localhost:8000/api/style/1")
                 .basic_auth("ingalls", Some("yeaheh"))
@@ -85,6 +85,16 @@ mod test {
                 .unwrap();
             assert_eq!(resp.text().unwrap(), r#"{"id":1,"name":"Awesome Style","style":"I am a style"}"#);
             assert!(resp.status().is_success());
+        }
+
+        { //Get Non-Existant Style - Auth: ingalls
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/style/100")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"Style Not Found"#);
+            assert!(resp.status().is_client_error());
         }
 
         { //Delete Style - No Auth

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -225,6 +225,12 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Get List of Public Styles
+            let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
+            assert_eq!(resp.text().unwrap(), "[]");
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -67,7 +67,7 @@ mod test {
 
         { //Get Style - No Auth
             let mut resp = reqwest::get("http://localhost:8000/api/style/1").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert_eq!(resp.text().unwrap(), "Style Not Found");
             assert!(resp.status().is_client_error());
         }
 
@@ -147,7 +147,7 @@ mod test {
             let mut resp = client.delete("http://localhost:8000/api/style/1")
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), r#"{"code":401,"reason":"You must be logged in to access this resource","status":"Not Authorized"}"#);
+            assert_eq!(resp.text().unwrap(), "Not Authorized!");
             assert!(resp.status().is_client_error());
         }
 
@@ -220,6 +220,15 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Get Public Style - No Auth
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/style/2")
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"{"id":2,"name":"Style 1","style":"I am a style"}"#);
+            assert!(resp.status().is_success());
+        }
+
         { //Get List of Public Styles - Style 1 should now appear, since it is now public
             let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
             assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1}]"#);
@@ -229,6 +238,16 @@ mod test {
         { //Get User List of Public Styles - Style 1 should now appear, since it is now public
             let mut resp = reqwest::get("http://localhost:8000/api/styles/1").unwrap();
             assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1}]"#);
+            assert!(resp.status().is_success());
+        }
+
+        { //Get User List of All Styles - authed user checking their own styles should see all
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/styles/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+            assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1},{"id":3,"name":"Style 2","public":false,"uid":1}]"#);
             assert!(resp.status().is_success());
         }
 
@@ -243,7 +262,7 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        { //Get List of Public Styles - Style 1 should now appear, since it is now public
+        { //Get List of Public Styles - Style 1 should not appear as it is private again
             let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
             assert_eq!(resp.text().unwrap(), "[]");
             assert!(resp.status().is_success());

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -209,15 +209,16 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        { //Create Style 3 For List Tests
+        { //Get List of Public Styles
+            let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
+            assert_eq!(resp.text().unwrap(), "[]");
+            assert!(resp.status().is_success());
+        }
+
+        { //Mark Style 1 as Public
             let client = reqwest::Client::new();
-            let mut resp = client.post("http://localhost:8000/api/style")
-                .body(r#"{
-                    "name": "Style 2",
-                    "style": "I am a style"
-                }"#)
+            let mut resp = client.post("http://localhost:8000/api/style/2/public")
                 .basic_auth("ingalls", Some("yeaheh"))
-                .header(reqwest::header::ContentType::json())
                 .send()
                 .unwrap();
 
@@ -225,7 +226,24 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        { //Get List of Public Styles
+        { //Get List of Public Styles - Style 1 should now appear, since it is now public
+            let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
+            assert_eq!(resp.text().unwrap(), r#"[{"id":2,"name":"Style 1","public":true,"uid":1}]"#);
+            assert!(resp.status().is_success());
+        }
+
+        { //Mark Style 1 as Private again
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/style/2/private")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Get List of Public Styles - Style 1 should now appear, since it is now public
             let mut resp = reqwest::get("http://localhost:8000/api/styles").unwrap();
             assert_eq!(resp.text().unwrap(), "[]");
             assert!(resp.status().is_success());

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -90,7 +90,7 @@ mod test {
 
             let tile: Vec<u8> = res.get(0).get(1);
 
-            assert_eq!(tile.len(), 10);
+            assert_eq!(tile.len(), 65);
         }
 
         { //Request a tile via API
@@ -100,7 +100,7 @@ mod test {
             let mut body: Vec<u8> = Vec::new();
             resp.read_to_end(&mut body).unwrap();
 
-            assert_eq!(body.len(), 13);
+            assert_eq!(body.len(), 100);
             assert!(resp.status().is_success());
         }
 

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -39,14 +39,43 @@ mod test {
         let mut server = Command::new("cargo").arg("run").spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
+        { //Create Username
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls&password=yeaheh&email=ingalls@protonmail.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "type": "Feature",
+                    "action": "create",
+                    "message": "Creating a Point",
+                    "properties": {
+                        "string": "123",
+                        "number": 123,
+                        "array": [ 1, 2, 3 ]
+                    },
+                    "geometry": { "type": "Point", "coordinates": [ -97.734375,56.559482483762245 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+            assert_eq!(resp.text().unwrap(), "true");
+        }
+
         { //Request a tile via API
             let client = reqwest::Client::new();
-            let mut resp = client.get("http://localhost:8000/api/tiles/1/2/3").send().unwrap();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0").send().unwrap();
 
             let mut body: Vec<u8> = Vec::new();
             resp.read_to_end(&mut body).unwrap();
 
-            assert_eq!(body.len(), 13);
+            assert_eq!(body.len(), 100);
             assert!(resp.status().is_success());
         }
 
@@ -57,7 +86,7 @@ mod test {
             assert_eq!(res.len(), 1);
 
             let tile_ref: String = res.get(0).get(0);
-            assert_eq!(tile_ref, String::from("1/2/3"));
+            assert_eq!(tile_ref, String::from("1/0/0"));
 
             let tile: Vec<u8> = res.get(0).get(1);
 
@@ -66,7 +95,7 @@ mod test {
 
         { //Request a tile via API
             let client = reqwest::Client::new();
-            let mut resp = client.get("http://localhost:8000/api/tiles/1/2/3").send().unwrap();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0").send().unwrap();
 
             let mut body: Vec<u8> = Vec::new();
             resp.read_to_end(&mut body).unwrap();

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -70,7 +70,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
+            assert_eq!(resp.text().unwrap(), "Not Authorized!");
         }
 
         { //Feature Upload with bad username


### PR DESCRIPTION
Allow user to create, edit, delete, & fork styles that can be applied to underlying hecate managed data

## Task List

- Create Styles
    - [x] Create Style API
    - [x] Create Style Tests
- Delete Styles
    - [x] Delete Style API
    - [x] Delete Style Tests
- Modify Styles
    - [x] Modify Style API
    - [x] Modify Style Tests
- Private Styles
    - [x] Private Style API
    - [x] Private Style Tests
- Public Styles
    - [x] Public Style API
    - [x] Public Style Tests
- Get Styles
    - [x] Get Style API
    - [x] Get Style Tests
- List Public Styles
    - [x] List Public Styles
    - [x] List Public Styles Tests
- List User Styles (authed - all)
    - [x] List User Styles (authed)
    - [x] List User Styles Tests (authed)
- List User Styles (not-authed - public)
    - [x] List User Styles (public)
    - [x] List User Styles Tests (public)

## Relevant Reading

Ref: https://github.com/ingalls/Hecate/issues/32
Ref: https://github.com/ingalls/Hecate/issues/31