### PR TITLE
MVT Tile Regen API

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,28 @@ Request a vector tile for a given set of coordinates. A [Mapbox Vector Tile](htt
 *Example*
 
 ```bash
-curl -X GET 'http://localhost:8000/api/user/create?ingalls&password=yeaheh&email=ingalls@protonmail.com
+curl -X GET 'http://localhost:8000/api/tiles/1/1/1
+```
+
+---
+
+#### `GET` `/api/tiles/<z>/<x>/<y>/regen`
+
+Allows an authenticated user to request a new tile for the given tile coordinates,
+ensuring the tile isn't returned from the tile cache.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `<z>` | `REQUIRED` Desired zoom level for tile
+| `<x>` | `REQUIRED` Desired x coordinate for tile
+| `<y>` | `REQUIRED` Desired y coordinate for tle
+
+*Example*
+
+```bash
+curl -X GET 'http://username:password@localhost:8000/api/tiles/1/1/1/regen
 ```
 
 ---

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -126,11 +126,13 @@ pub fn db_cache(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionM
     }
 }
 
-pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32) -> Result<proto::Tile, MVTError> {
-    match db_get(&conn, format!("{}/{}/{}", &z, &x, &y))? {
-        Some(tile) => { return Ok(tile); }
-        _ => ()
-    };
+pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32, regen: bool) -> Result<proto::Tile, MVTError> {
+    if regen == false {
+        match db_get(&conn, format!("{}/{}/{}", &z, &x, &y))? {
+            Some(tile) => { return Ok(tile); }
+            _ => ()
+        };
+    }
 
     let tile = db_create(&conn, &z, &x, &y)?;
 

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -104,6 +104,28 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Request a tile regen - unauthenticated
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0/regen").send().unwrap();
+
+            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Request a tile regen - authenticated
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0/regen")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            let mut body: Vec<u8> = Vec::new();
+            resp.read_to_end(&mut body).unwrap();
+
+            assert_eq!(body.len(), 100);
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }


### PR DESCRIPTION
Add `GET` endpoint for `/api/tiles/<z>/<x>/<y>/regen`

When requested this endpoint would skip the cache and regenerate/recache the requested tile

Closes: https://github.com/ingalls/Hecate/issues/27