### PR TITLE
MVT Meta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,26 @@ curl -X GET 'http://localhost:8000/api/tiles/1/1/1
 
 ---
 
+#### `GET` `/api/tiles/<z>/<x>/<y>/meta`
+
+Return any stored metadata about a given tile.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `<z>` | `REQUIRED` Desired zoom level for tile
+| `<x>` | `REQUIRED` Desired x coordinate for tile
+| `<y>` | `REQUIRED` Desired y coordinate for tle
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/tiles/1/1/1/meta
+```
+
+---
+
 #### `GET` `/api/tiles/<z>/<x>/<y>/regen`
 
 Allows an authenticated user to request a new tile for the given tile coordinates,

--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -126,6 +126,29 @@ pub fn db_cache(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionM
     }
 }
 
+pub fn meta(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32) -> Result<serde_json::Value, MVTError> {
+    let rows = match conn.query("
+        SELECT
+            COALESCE(row_to_json(t), '{}'::JSON)
+        FROM (
+            SELECT
+                created AS created
+            FROM
+                tiles
+            WHERE
+                ref = $1
+        ) t
+    ", &[&coord]) {
+        Ok(rows) => {
+
+        },
+        Err(err) => match err.as_db() {
+            Some(_e) => { return Err(MVTError::DB); },
+            _ => { return Err(MVTError::DB); }
+        }
+    };
+}
+
 pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, z: u8, x: u32, y: u32) -> Result<proto::Tile, MVTError> {
     match db_get(&conn, format!("{}/{}/{}", &z, &x, &y))? {
         Some(tile) => { return Ok(tile); }

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -112,6 +112,14 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
+        { //Request a tile meta
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0/meta").send().unwrap();
+
+            assert!(resp.text().unwrap().contains("created"));
+            assert!(resp.status().is_success());
+        }
+
         { //Request a tile regen - authenticated
             let client = reqwest::Client::new();
             let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0/regen")


### PR DESCRIPTION
Add `GET` endpoint for `/api/tiles/<z>/<x>/<y>/meta`

This would return a JSON object containing at minimum the time at which the vector tile was created.

```JSON
{
    "created": "ISO DATESTAMP"
}
```

Closes: https://github.com/ingalls/Hecate/issues/26