### PR TITLE
XML Upload could leak neg ids into delta

### DIFF
--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -31,6 +31,7 @@ pub enum Action {
     Delete
 }
 
+#[derive(PartialEq, Debug)]
 pub struct Response {
     pub old: Option<i64>,
     pub new: Option<i64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,7 @@ fn xml_changeset_upload(auth: user::Auth, conn: DbConn, schema: State<Option<ser
                 return Ok(status::Custom(HTTPStatus::ExpectationFailed, err.to_string()));
             },
             Ok(feat_res) => {
-                if feat_res.old == None {
+                if feat_res.old.unwrap_or(0) < 0 {
                     feat.id = Some(json!(feat_res.new));
                 }
 


### PR DESCRIPTION
Previously

```
hecate=# SELECT affected FROM deltas;
 affected 
----------
 {-1}
 {1}
 {1}
(3 rows)

```

This `-1` value is coming from JOSM/iDs internal space which stores new features as a negative id until they are uploaded. This negative id is ephemeral and should not be stored by hecate.

Now:

```
hecate=# SELECT affected FROM deltas;
 affected 
----------
 {1}
 {1}
 {1}
(3 rows)

```
