### PR TITLE
Custom Auth Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Meta](#meta)
     - [Admin Interface](#admin-interface)
     - [Schema](#schema)
+    - [Auth](#Auth)
     - [Styles](#styles)
     - [Vector Tiles](#vector-tiles)
     - [Cloning the Server](#downloading-clone)
@@ -338,6 +339,8 @@ have a map containing the auth for each subkey.
 | `GET /api`                            | `meta`                    | `public`      | All                       |       |
 | **JSON Schema**                       | `schema`                  |               | `null`                    | 2     |
 | `GET /api/schema`                     | `schema::get`             | `public`      | All                       |       |
+| **Custom Auth JSON**                  | `auth`                    |               | `null`                    | 2     |
+| `GET /api/auth`                       | `auth::get`               | `public`      | All                       |       |
 | **Mapbox Vector Tiles**               | `mvt`                     |               | `null`                    | 2     |
 | `GET /api/tiles/<z>/<x>/<y>`          | `mvt::get`                | `public`      | All                       |       |
 | `GET /api/tiles/<z>/<x>/<y>/regen`    | `mvt::regen`              | `user`        | All                       |       |
@@ -586,6 +589,22 @@ Return a JSON object containing the schema used by the server or return a 404 if
 
 ```bash
 curl -X GET 'http://localhost:8000/api/schema
+```
+
+---
+
+<h3 align='center'>Auth</h3>
+
+#### `GET` `/api/auth`
+
+Returns a JSON object containing the servers auth permissions as defined by the default
+auth rules or the custom JSON auth as defined in the `Custom Authentication` section
+of this guide
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/auth
 ```
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub fn start(database: String, schema: Option<serde_json::value::Value>, auth: O
         .mount("/api", routes![
             meta,
             schema_get,
+            auth_get,
             mvt_get,
             mvt_meta,
             mvt_regen,
@@ -471,6 +472,13 @@ fn schema_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::Custom
         Some(s) => Ok(Json(json!(s.clone()))),
         None => Err(status::Custom(HTTPStatus::NotFound, String::from("No Schema Validation Enforced")))
     }
+}
+
+#[get("/auth")]
+fn auth_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+    auth_rules.allows_auth_get(&mut auth, &conn.0)?;
+
+    Ok(Json(auth_rules.to_json()))
 }
 
 #[post("/data/features", format="application/json", data="<body>")]

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -1,5 +1,6 @@
 extern crate reqwest;
 extern crate postgres;
+#[macro_use] extern crate serde_json;
 
 #[cfg(test)]
 mod test {
@@ -11,6 +12,7 @@ mod test {
     use std::time::Duration;
     use std::thread;
     use reqwest;
+    use serde_json::value::Value;
 
     #[test]
     fn auth_closed() {
@@ -134,6 +136,63 @@ mod test {
                 .send()
                 .unwrap();
 
+            assert!(resp.status().is_success());
+        }
+
+        {
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/auth").send().unwrap();
+
+            let resp_value: Value = resp.json().unwrap();
+
+            assert_eq!(resp_value, json!({
+                "meta": "user",
+                "schema": {
+                    "get": "user"
+                },
+                "mvt": {
+                    "get": "user",
+                    "regen": "user",
+                    "meta": "user"
+                },
+                "user": {
+                    "info": "self",
+                    "create": "public",
+                    "create_session": "self"
+                },
+                "style": {
+                    "create": "self",
+                    "patch": "self",
+                    "set_public": "self",
+                    "set_private": "self",
+                    "delete": "self",
+                    "get": "user",
+                    "list": "user"
+                },  
+                "delta": {
+                    "get": "user",
+                    "list": "user"
+                },
+                "feature": {
+                    "create": "user",
+                    "get": "user",
+                    "history": "user"
+                },  
+                "bounds": {
+                    "list": "user",
+                    "get": "user"
+                },
+                "osm": {
+                    "get": "user",
+                    "create": "user"
+                },
+                "clone": {
+                    "get": "user"
+                },
+                "auth": {
+                    "get": "public"
+                }
+            }));
             assert!(resp.status().is_success());
         }
 

--- a/tests/fixtures/auth.closed.json
+++ b/tests/fixtures/auth.closed.json
@@ -41,5 +41,8 @@
     },
     "clone": {
         "get": "user"
+    },
+    "auth": {
+        "get": "public"
     }
 }


### PR DESCRIPTION
As a followup to introducing Custom Authentication, add an API endpoint to return the current Custom Auth JSON. This allows generic hecate integrations to allow or disallow certain features.

For example, once implemented the Hecate UI could conditionally disable the `bounds` or `deltas` list if the user wasn't allowed to view them, instead of hard failing.