### PR TITLE
Restore Feature Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ A feature being uploaded for restoration must have the `action: restore` as well
 Restore places the new given geometry/properties at the id specified. It does not automatically roll back the feature to it's state before deletion, if this is desired, one
 must use the Feature History API to get the state before deletion and then perform the `restore` action.
 
+Note: Restore will throw an error if an feature still exists.
+
 ## Server
 
 This section of the guide goes over various options on has when launching the server

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ server members.
 | :-------: | ----- |
 | `id`      | The unique integer `id` of a given feature. Note that all features get a unique id accross GeoJSON Geometry Type |
 | `version` | The version of a given feature, starts at `1` for a newly created feature |
-| `action`  | Only used for uploads, the desired action to be performed. One of `create`, `modify` or `delete` |
+| `action`  | Only used for uploads, the desired action to be performed. One of `create`, `modify`, `delete`, or `restore` |
 
 
 ### Examples
@@ -218,7 +218,29 @@ A feature being uploaded for deletion must have the `action: delete` as well as 
 
 Note the `properties` and `geometry` attributes must still be included. They can be set to `null` or be their previous value. They will be ignored.
 
-### Samples
+#### Restore Features
+
+```JSON
+{
+    "id": 123,
+    "version": 2,
+    "action": "restore",
+    "type": "Feature",
+    "properties": {
+        "test": true,
+        "random_array": [1, 2, 3]
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [ 12.34, 56.78 ]
+    }
+}
+```
+
+A feature being uploaded for restoration must have the `action: restore` as well as the `id` and `version` properties. A `restore` action is just a `modify` on a deleted feature.
+
+Restore places the new given geometry/properties at the id specified. It does not automatically roll back the feature to it's state before deletion, if this is desired, one
+must use the Feature History API to get the state before deletion and then perform the `restore` action.
 
 ## Server
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -43,7 +43,7 @@ DROP TABLE IF EXISTS geo;
 DROP INDEX IF EXISTS geo_gist;
 DROP INDEX IF EXISTS geo_idx;
 CREATE TABLE geo (
-    id          BIGSERIAL,
+    id          BIGSERIAL UNIQUE,
     version     BIGINT,
     geom        GEOMETRY(GEOMETRY, 4326),
     props       JSONB,

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -465,6 +465,32 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
+        { //Restore Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 3,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        {
+            let resp = reqwest::get("http://localhost:8000/api/data/feature/1").unwrap();
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -253,6 +253,27 @@ mod test {
             //TODO check body
         }
 
+        { //Restore Point - Feature Exists! (Should be right after create as there is a short circuit for newly created features that are attempted to be restored)
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 1,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1 cannot restore an existing feature");
+            assert!(resp.status().is_client_error());
+        }
+
         { //Modify Point
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/feature")
@@ -278,6 +299,27 @@ mod test {
             let resp = reqwest::get("http://localhost:8000/api/data/feature/1").unwrap();
             assert!(resp.status().is_success());
             //TODO check body
+        }
+
+        { //Restore Point - Feature Exists! (Should be right after a create & >= 1 Modify - fails due to unique id check)
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 2,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1 cannot restore an existing feature");
+            assert!(resp.status().is_client_error());
         }
 
         { //Modify MultiPoint
@@ -306,7 +348,7 @@ mod test {
             assert!(resp.status().is_success());
             //TODO check body
         }
-        
+
         { //Modify LineString
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/feature")
@@ -360,7 +402,7 @@ mod test {
             assert!(resp.status().is_success());
             //TODO check body
         }
-        
+
         { //Delete Point
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/feature")
@@ -412,7 +454,7 @@ mod test {
             let resp = reqwest::get("http://localhost:8000/api/data/feature/2").unwrap();
             assert!(resp.status().is_client_error());
         }
-        
+
         { //Delete LineString
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/feature")
@@ -464,6 +506,49 @@ mod test {
             let resp = reqwest::get("http://localhost:8000/api/data/feature/4").unwrap();
             assert!(resp.status().is_client_error());
         }
+
+        { //Restore Point - Error Wrong Version
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 2,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "Restore Version Mismatch");
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Restore Point - Feature Doesn't Exist
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1000,
+                    "type": "Feature",
+                    "version": 2,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1000 does not exist");
+            assert!(resp.status().is_client_error());
+        }
+
 
         { //Restore Point
             let client = reqwest::Client::new();


### PR DESCRIPTION
Adds a transaction safe `action` for restoring a feature that has been deleted back into existence with it's previous id. 

This will primarily be used during reversions of bad deltas. Previously reverting a delete in a bad delta could only be accomplished via a subsequent create whcih would result in the feature that was deleted being recreated with a new id.