### PR TITLE
Consistent Import Errors

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -11,11 +11,15 @@ use self::rocket::http::Status;
 use self::rocket::{Request, Outcome};
 use self::rocket::response::status;
 use self::rocket::http::Status as HTTPStatus;
+use rocket_contrib::Json;
 
 
-fn not_authed() -> status::Custom<String> {
-    let auth: status::Custom<String> = status::Custom(HTTPStatus::Unauthorized, String::from("Not Authorized!"));
-    return auth;
+fn not_authed() -> status::Custom<Json> {
+    status::Custom(HTTPStatus::Unauthorized, Json(json!({
+        "code": 401,
+        "status": "Not Authorized",
+        "reason": "You must be logged in to access this resource"
+    })))
 }
 
 ///
@@ -410,7 +414,7 @@ impl ValidAuth for CustomAuth {
 /// Determines whether the current auth state meets or exceeds the
 /// requirements of an endpoint
 ///
-fn auth_met(required: &Option<String>, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+fn auth_met(required: &Option<String>, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
     auth.validate(conn)?;
 
     match required {
@@ -472,179 +476,179 @@ impl CustomAuth {
         json_auth
     }
 
-    pub fn allows_meta(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_meta(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         auth_met(&self.meta, auth, &conn)
     }
 
-    pub fn allows_mvt_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_mvt_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.mvt {
             None => Err(not_authed()),
             Some(mvt) => auth_met(&mvt.get, auth, &conn)
         }
     }
 
-    pub fn allows_mvt_regen(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_mvt_regen(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.mvt {
             None => Err(not_authed()),
             Some(mvt) => auth_met(&mvt.regen, auth, &conn)
         }
     }
 
-    pub fn allows_mvt_meta(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_mvt_meta(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.mvt {
             None => Err(not_authed()),
             Some(mvt) => auth_met(&mvt.meta, auth, &conn)
         }
     }
 
-    pub fn allows_user_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_user_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.user {
             None => Err(not_authed()),
             Some(user) => auth_met(&user.create, auth, &conn)
         }
     }
 
-    pub fn allows_user_info(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_user_info(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.user {
             None => Err(not_authed()),
             Some(user) => auth_met(&user.info, auth, &conn)
         }
     }
 
-    pub fn allows_user_create_session(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_user_create_session(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.user {
             None => Err(not_authed()),
             Some(user) => auth_met(&user.create_session, auth, &conn)
         }
     }
 
-    pub fn allows_style_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.create, auth, &conn)
         }
     }
 
-    pub fn allows_style_patch(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_patch(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.patch, auth, &conn)
         }
     }
 
-    pub fn allows_style_set_public(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_set_public(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.set_public, auth, &conn)
         }
     }
 
-    pub fn allows_style_set_private(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_set_private(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.set_private, auth, &conn)
         }
     }
 
-    pub fn allows_style_delete(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_delete(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.delete, auth, &conn)
         }
     }
 
-    pub fn allows_style_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.get, auth, &conn)
         }
     }
 
-    pub fn allows_style_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_style_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.style {
             None => Err(not_authed()),
             Some(style) => auth_met(&style.list, auth, &conn)
         }
     }
 
-    pub fn allows_delta_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_delta_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.delta {
             None => Err(not_authed()),
             Some(delta) => auth_met(&delta.get, auth, &conn)
         }
     }
 
-    pub fn allows_delta_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_delta_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.delta {
             None => Err(not_authed()),
             Some(delta) => auth_met(&delta.list, auth, &conn)
         }
     }
 
-    pub fn allows_clone_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_clone_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.clone {
             None => Err(not_authed()),
             Some(clone) => auth_met(&clone.get, auth, &conn)
         }
     }
 
-    pub fn allows_bounds_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_bounds_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.bounds {
             None => Err(not_authed()),
             Some(bounds) => auth_met(&bounds.get, auth, &conn)
         }
     }
 
-    pub fn allows_bounds_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_bounds_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.bounds {
             None => Err(not_authed()),
             Some(bounds) => auth_met(&bounds.list, auth, &conn)
         }
     }
 
-    pub fn allows_feature_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_feature_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.feature {
             None => Err(not_authed()),
             Some(feature) => auth_met(&feature.create, auth, &conn)
         }
     }
 
-    pub fn allows_feature_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_feature_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.feature {
             None => Err(not_authed()),
             Some(feature) => auth_met(&feature.get, auth, &conn)
         }
     }
 
-    pub fn allows_feature_history(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_feature_history(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.feature {
             None => Err(not_authed()),
             Some(feature) => auth_met(&feature.history, auth, &conn)
         }
     }
 
-    pub fn allows_schema_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_schema_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.schema {
             None => Err(not_authed()),
             Some(schema) => auth_met(&schema.get, auth, &conn)
         }
     }
 
-    pub fn allows_auth_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_auth_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.auth {
             None => Err(not_authed()),
             Some(a) => auth_met(&a.get, auth, &conn)
         }
     }
 
-    pub fn allows_osm_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_osm_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.osm {
             None => Err(not_authed()),
             Some(osm) => auth_met(&osm.get, auth, &conn)
         }
     }
 
-    pub fn allows_osm_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<String>> {
+    pub fn allows_osm_create(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.osm {
             None => Err(not_authed()),
             Some(osm) => auth_met(&osm.create, auth, &conn)
@@ -697,7 +701,7 @@ impl Auth {
     ///
     /// Note: Once validated the token/basic auth used to validate the user will be set to null
     ///
-    pub fn validate(&mut self, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Option<i64>, status::Custom<String>> {
+    pub fn validate(&mut self, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Option<i64>, status::Custom<Json>> {
         if self.basic.is_some() {
             let (username, password) = self.basic.clone().unwrap();
 

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -11,9 +11,9 @@ use serde_json::value::Value;
 #[derive(PartialEq, Debug)]
 pub enum FeatureError {
     NotFound,
-    ImportError(Value),
     InvalidBBOX,
-    InvalidFeature
+    InvalidFeature,
+    ImportError(Value)
 }
 
 #[derive(PartialEq, Debug)]
@@ -32,12 +32,12 @@ pub struct Response {
 }
 
 impl FeatureError {
-    pub fn to_string(&self) -> String {
+    pub fn as_json(&self) -> Value {
         match *self {
-            FeatureError::NotFound => String::from("Feature Not Found"),
-            FeatureError::ImportError(ref value) => format!("Import Error: {}", value["error"]),
-            FeatureError::InvalidBBOX => String::from("Invalid BBOX"),
-            FeatureError::InvalidFeature => String::from("Invalid Feature")
+            FeatureError::NotFound => json!("Feature Not Found"),
+            FeatureError::ImportError(ref value) => json!(value),
+            FeatureError::InvalidBBOX => json!("Invalid BBOX"),
+            FeatureError::InvalidFeature => json!("Invalid Feature")
         }
     }
 }

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -2,29 +2,16 @@ extern crate r2d2;
 extern crate r2d2_postgres;
 extern crate geojson;
 extern crate postgres;
-extern crate serde_json;
 extern crate valico;
+extern crate serde_json;
 
 use stream::PGStream;
+use serde_json::value::Value;
 
 #[derive(PartialEq, Debug)]
 pub enum FeatureError {
     NotFound,
-    NoProps,
-    NoMembers,
-    NoGeometry,
-    DuplicateKey,
-    VersionRequired,
-    SchemaMisMatch,
-    CreateError(String),
-    DeleteVersionMismatch,
-    DeleteError(String),
-    ModifyError(String),
-    RestoreError(String),
-    ModifyVersionMismatch,
-    RestoreVersionMismatch,
-    IdRequired,
-    ActionRequired,
+    ImportError(Value),
     InvalidBBOX,
     InvalidFeature
 }
@@ -48,25 +35,19 @@ impl FeatureError {
     pub fn to_string(&self) -> String {
         match *self {
             FeatureError::NotFound => String::from("Feature Not Found"),
-            FeatureError::NoProps => String::from("No Properties"),
-            FeatureError::NoMembers => String::from("No Members"),
-            FeatureError::NoGeometry => String::from("No Geometry"),
-            FeatureError::DuplicateKey => String::from("Duplicate Key Value"),
-            FeatureError::VersionRequired => String::from("Version Required"),
-            FeatureError::SchemaMisMatch => String::from("Feature properties do not pass schema definition"),
-            FeatureError::CreateError(ref msg) => format!("Create Error: {}", msg),
-            FeatureError::DeleteVersionMismatch => String::from("Delete Version Mismatch"),
-            FeatureError::DeleteError(ref msg) => format!("Delete Error: {}", msg),
-            FeatureError::ModifyVersionMismatch => String::from("Modify Version Mismatch"),
-            FeatureError::RestoreVersionMismatch => String::from("Restore Version Mismatch"),
-            FeatureError::ModifyError(ref msg) => format!("Modify Error: {}", msg),
-            FeatureError::RestoreError(ref msg) => format!("Restore Error: {}", msg),
-            FeatureError::IdRequired => String::from( "ID Required"),
-            FeatureError::ActionRequired => String::from( "Action Required"),
-            FeatureError::InvalidBBOX => String::from( "Invalid BBOX"),
-            FeatureError::InvalidFeature => String::from( "Invalid Feature")
+            FeatureError::ImportError(ref value) => format!("Import Error: {}", value["error"]),
+            FeatureError::InvalidBBOX => String::from("Invalid BBOX"),
+            FeatureError::InvalidFeature => String::from("Invalid Feature")
         }
     }
+}
+
+pub fn import_error(feat: &geojson::Feature, error: &str) -> FeatureError {
+    FeatureError::ImportError(json!({
+        "id": feat.id.clone(),
+        "message": error,
+        "feature": feat.clone()
+    }))
 }
 
 pub fn del_version(feat: &mut geojson::Feature) {
@@ -80,32 +61,32 @@ pub fn del_version(feat: &mut geojson::Feature) {
 
 pub fn get_version(feat: &geojson::Feature) -> Result<i64, FeatureError> {
     match feat.foreign_members {
-        None => { return Err(FeatureError::VersionRequired); },
+        None => { return Err(import_error(&feat, "Version Required")); },
         Some(ref members) => match members.get("version") {
             Some(version) => {
                 match version.as_i64() {
                     Some(version) => Ok(version),
-                    None => { return Err(FeatureError::VersionRequired); },
+                    None => { return Err(import_error(&feat, "Version Required")); },
                 }
             },
-            None => { return Err(FeatureError::VersionRequired); },
+            None => { return Err(import_error(&feat, "Version Required")); },
         }
     }
 }
 
 pub fn get_id(feat: &geojson::Feature) -> Result<i64, FeatureError> {
     match feat.id {
-        None => { return Err(FeatureError::IdRequired); },
+        None => { return Err(import_error(&feat, "ID Required")); },
         Some(ref id) => match id.as_i64() {
             Some(id) => Ok(id),
-            None => { return Err(FeatureError::IdRequired); },
+            None => { return Err(import_error(&feat, "ID Required")); },
         }
     }
 }
 
 pub fn get_action(feat: &geojson::Feature) -> Result<Action, FeatureError> {
     match feat.foreign_members {
-        None => { return Err(FeatureError::ActionRequired); },
+        None => { return Err(import_error(&feat, "Action Required")); },
         Some(ref members) => match members.get("action") {
             Some(action) => {
                 match action.as_str() {
@@ -113,11 +94,11 @@ pub fn get_action(feat: &geojson::Feature) -> Result<Action, FeatureError> {
                     Some("modify") => Ok(Action::Modify),
                     Some("delete") => Ok(Action::Delete),
                     Some("restore") => Ok(Action::Restore),
-                    Some(_) => { return Err(FeatureError::ActionRequired); },
-                    None => { return Err(FeatureError::ActionRequired); }
+                    Some(_) => { return Err(import_error(&feat, "Action Required")); },
+                    None => { return Err(import_error(&feat, "Action Required")); }
                 }
             },
-            None => { return Err(FeatureError::ActionRequired); },
+            None => { return Err(import_error(&feat, "Action Required")); },
         }
     }
 }
@@ -163,16 +144,16 @@ pub fn action(trans: &postgres::transaction::Transaction, schema_json: &Option<s
 
 pub fn create(trans: &postgres::transaction::Transaction, schema: &Option<valico::json_schema::schema::ScopedSchema>, feat: &geojson::Feature, delta: &Option<i64>) -> Result<Response, FeatureError> {
     if get_version(&feat).is_ok() {
-        return Err(FeatureError::CreateError(String::from("Should not have 'version' property")));
+        return Err(import_error(&feat, "Cannot have Version"));
     }
 
     let geom = match feat.geometry {
-        None => { return Err(FeatureError::NoGeometry); },
+        None => { return Err(import_error(&feat, "Geometry Required")); },
         Some(ref geom) => geom
     };
 
     let props = match feat.properties {
-        None => { return Err(FeatureError::NoProps); },
+        None => { return Err(import_error(&feat, "Properties Required")); },
         Some(ref props) => props
     };
 
@@ -183,7 +164,7 @@ pub fn create(trans: &postgres::transaction::Transaction, schema: &Option<valico
         &None => true
     };
 
-    if !valid { return Err(FeatureError::SchemaMisMatch) };
+    if !valid { return Err(import_error(&feat, "Failed to Match Schema")) };
 
     let geom_str = serde_json::to_string(&geom).unwrap();
     let props_str = serde_json::to_string(&props).unwrap();
@@ -214,12 +195,12 @@ pub fn create(trans: &postgres::transaction::Transaction, schema: &Option<valico
             match err.as_db() {
                 Some(e) => {
                     if e.message == "duplicate key value violates unique constraint \"geo_key_key\"" {
-                        Err(FeatureError::DuplicateKey)
+                        Err(import_error(&feat, "Duplicate Key Value"))
                     } else {
-                        Err(FeatureError::CreateError(e.message.clone()))
+                        Err(import_error(&feat, &*e.message.clone()))
                     }
                 },
-                _ => Err(FeatureError::CreateError(String::from("generic")))
+                _ => Err(import_error(&feat, "Generic Error"))
             }
         }
     }
@@ -227,12 +208,12 @@ pub fn create(trans: &postgres::transaction::Transaction, schema: &Option<valico
 
 pub fn modify(trans: &postgres::transaction::Transaction, schema: &Option<valico::json_schema::schema::ScopedSchema>, feat: &geojson::Feature, delta: &Option<i64>) -> Result<Response, FeatureError> {
     let geom = match feat.geometry {
-        None => { return Err(FeatureError::NoGeometry); },
+        None => { return Err(import_error(&feat, "Geometry Required")); },
         Some(ref geom) => geom
     };
 
     let props = match feat.properties {
-        None => { return Err(FeatureError::NoProps); },
+        None => { return Err(import_error(&feat, "Properties Required")); },
         Some(ref props) => props
     };
 
@@ -243,7 +224,7 @@ pub fn modify(trans: &postgres::transaction::Transaction, schema: &Option<valico
         &None => true
     };
 
-    if !valid { return Err(FeatureError::SchemaMisMatch) };
+    if !valid { return Err(import_error(&feat, "Failed to Match Schema")) };
 
     let id = get_id(&feat)?;
     let version = get_version(&feat)?;
@@ -262,14 +243,14 @@ pub fn modify(trans: &postgres::transaction::Transaction, schema: &Option<valico
             match err.as_db() {
                 Some(e) => {
                     if e.message == "MODIFY: ID or VERSION Mismatch" {
-                        Err(FeatureError::ModifyVersionMismatch)
+                        Err(import_error(&feat, "Modify Version Mismatch"))
                     } else if e.message == "duplicate key value violates unique constraint \"geo_key_key\"" {
-                        Err(FeatureError::DuplicateKey)
+                        Err(import_error(&feat, "Duplicate Key Value"))
                     } else {
-                        Err(FeatureError::CreateError(e.message.clone()))
+                        Err(import_error(&feat, &*e.message.clone()))
                     }
                 },
-                _ => Err(FeatureError::ModifyError(String::from("generic")))
+                _ => Err(import_error(&feat, "Generic Error"))
             }
         }
     }
@@ -289,12 +270,12 @@ pub fn delete(trans: &postgres::transaction::Transaction, feat: &geojson::Featur
             match err.as_db() {
                 Some(e) => {
                     if e.message == "DELETE: ID or VERSION Mismatch" {
-                        Err(FeatureError::DeleteVersionMismatch)
+                        Err(import_error(&feat, "Delete Version Mismatch"))
                     } else {
-                        Err(FeatureError::DeleteError(e.message.clone()))
+                        Err(import_error(&feat, &*e.message.clone()))
                     }
                 },
-                _ => Err(FeatureError::DeleteError(String::from("generic")))
+                _ => Err(import_error(&feat, "Generic Error"))
             }
         }
     }
@@ -366,12 +347,12 @@ pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManage
 
 pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valico::json_schema::schema::ScopedSchema>, feat: &geojson::Feature, delta: &Option<i64>) -> Result<Response, FeatureError> {
     let geom = match feat.geometry {
-        None => { return Err(FeatureError::NoGeometry); },
+        None => { return Err(import_error(&feat, "Geometry Required")); },
         Some(ref geom) => geom
     };
 
     let props = match feat.properties {
-        None => { return Err(FeatureError::NoProps); },
+        None => { return Err(import_error(&feat, "Properties Required")); },
         Some(ref props) => props
     };
 
@@ -382,7 +363,7 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
         &None => true
     };
 
-    if !valid { return Err(FeatureError::SchemaMisMatch) };
+    if !valid { return Err(import_error(&feat, "Failed to Match Schema")) };
 
     let id = get_id(&feat)?;
     let version = get_version(&feat)?;
@@ -413,7 +394,7 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
         Ok(history) => {
 
             if history.len() != 1 {
-                return Err(FeatureError::RestoreError(format!("Feature id: {} does not exist", &id)));
+                return Err(import_error(&feat, "Feature Not Found"));
             }
 
             //Version will be None if the feature was created but has never been modified since the
@@ -421,11 +402,11 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
             let prev_version: Option<i64> = history.get(0).get(1);
             match prev_version {
                 None => {
-                    return Err(FeatureError::RestoreError(format!("Feature id: {} cannot restore an existing feature", &id)));
+                    return Err(import_error(&feat, "Feature Not In Deleted State"));
                 },
                 Some(prev_version) => {
                     if prev_version != version {
-                        return Err(FeatureError::RestoreVersionMismatch);
+                        return Err(import_error(&feat, "Restore Version Mismatch"));
                     }
                 }
             };
@@ -453,20 +434,20 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
                     match err.as_db() {
                         Some(e) => {
                             if e.message == "duplicate key value violates unique constraint \"geo_id_key\"" {
-                                Err(FeatureError::RestoreError(format!("Feature id: {} cannot restore an existing feature", &id)))
+                                Err(import_error(&feat, "Feature Not In Deleted State"))
                             } else if e.message == "duplicate key value violates unique constraint \"geo_key_key\"" {
-                                Err(FeatureError::DuplicateKey)
+                                Err(import_error(&feat, "Duplicate Key Value"))
                             } else {
-                                Err(FeatureError::RestoreError(String::from("generic")))
+                                Err(import_error(&feat, "Generic Error"))
                             }
                         }
-                        _ => Err(FeatureError::RestoreError(String::from("generic")))
+                        _ => Err(import_error(&feat, "Generic Error"))
                     }
                 }
             }
         },
         Err(_) => {
-            Err(FeatureError::RestoreError(format!("Error fetching feature history for: {}", &id)))
+            Err(import_error(&feat, "Error Fetching History"))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ fn not_found() -> Json {
 fn index() -> &'static str { "Hello World!" }
 
 #[get("/")]
-fn meta(mut auth: auth::Auth, conn: DbConn, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+fn meta(mut auth: auth::Auth, conn: DbConn, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_meta(&mut auth, &conn.0)?;
 
     Ok(Json(json!({
@@ -179,20 +179,20 @@ fn staticsrv(file: PathBuf) -> Option<NamedFile> {
 }
 
 #[get("/tiles/<z>/<x>/<y>")]
-fn mvt_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Response<'static>, status::Custom<String>> {
+fn mvt_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Response<'static>, status::Custom<Json>> {
     auth_rules.allows_mvt_get(&mut auth, &conn.0)?;
 
-    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, String::from("Tile Not Found"))); }
+    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, Json(json!("Tile Not Found")))); }
 
     let tile = match mvt::get(&conn.0, z, x, y, false) {
         Ok(tile) => tile,
-        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string())))); }
     };
 
     let mut c = Cursor::new(Vec::new());
     match tile.to_writer(&mut c) {
         Ok(_) => (),
-        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string())))); }
     }
 
     let mut mvt_response = Response::new();
@@ -203,32 +203,32 @@ fn mvt_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAut
 }
 
 #[get("/tiles/<z>/<x>/<y>/meta")]
-fn mvt_meta(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Json, status::Custom<String>> {
+fn mvt_meta(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_mvt_meta(&mut auth, &conn.0)?;
 
-    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, String::from("Tile Not Found"))); }
+    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, Json(json!("Tile Not Found")))); }
 
     match mvt::meta(&conn.0, z, x, y) {
         Ok(tile) => Ok(Json(tile)),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/tiles/<z>/<x>/<y>/regen")]
-fn mvt_regen(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Response<'static>, status::Custom<String>> {
+fn mvt_regen(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, z: u8, x: u32, y: u32) -> Result<Response<'static>, status::Custom<Json>> {
     auth_rules.allows_mvt_regen(&mut auth, &conn.0)?;
 
-    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, String::from("Tile Not Found"))); }
+    if z > 14 { return Err(status::Custom(HTTPStatus::NotFound, Json(json!("Tile Not Found")))); }
 
     let tile = match mvt::get(&conn.0, z, x, y, true) {
         Ok(tile) => tile,
-        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string())))); }
     };
 
     let mut c = Cursor::new(Vec::new());
     match tile.to_writer(&mut c) {
         Ok(_) => (),
-        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string())))); }
     }
 
     let mut mvt_response = Response::new();
@@ -251,29 +251,29 @@ struct Map {
 }
 
 #[get("/user/create?<user>")]
-fn user_create(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, user: User) -> Result<Json, status::Custom<String>> {
+fn user_create(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, user: User) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_user_create(&mut auth, &conn.0)?;
 
     match user::create(&conn.0, &user.username, &user.password, &user.email) {
         Ok(_) => Ok(Json(json!(true))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/user/info")]
-fn user_self(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+fn user_self(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_user_info(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
 
     match user::info(&conn.0, &uid) {
         Ok(info) => { Ok(Json(json!(info))) },
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/user/session")]
-fn user_create_session(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, mut cookies: Cookies) -> Result<Json, status::Custom<String>> {
+fn user_create_session(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, mut cookies: Cookies) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_user_create_session(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -283,88 +283,88 @@ fn user_create_session(conn: DbConn, mut auth: auth::Auth, auth_rules: State<aut
             cookies.add_private(Cookie::new("session", token));
             Ok(Json(json!(uid)))
         },
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[post("/style", format="application/json", data="<style>")]
-fn style_create(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, style: String) -> Result<Json, status::Custom<String>> {
+fn style_create(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, style: String) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_create(&mut auth, &conn.0)?;
     let uid = auth.uid.unwrap();
 
     match style::create(&conn.0, &uid, &style) {
         Ok(style_id) => Ok(Json(json!(style_id))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[post("/style/<id>/public")]
-fn style_public(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<String>> {
+fn style_public(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_set_public(&mut auth, &conn.0)?;
     let uid = auth.uid.unwrap();
 
     match style::access(&conn.0, &uid, &id, true) {
         Ok(updated) => Ok(Json(json!(updated))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[post("/style/<id>/private")]
-fn style_private(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<String>> {
+fn style_private(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_set_private(&mut auth, &conn.0)?;
     let uid = auth.uid.unwrap();
 
     match style::access(&conn.0, &uid, &id, false) {
         Ok(updated) => Ok(Json(json!(updated))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[patch("/style/<id>", format="application/json", data="<style>")]
-fn style_patch(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64, style: String) -> Result<Json, status::Custom<String>> {
+fn style_patch(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64, style: String) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_patch(&mut auth, &conn.0)?;
     let uid = auth.uid.unwrap();
 
     match style::update(&conn.0, &uid, &id, &style) {
         Ok(updated) => Ok(Json(json!(updated))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[delete("/style/<id>")]
-fn style_delete(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<String>> {
+fn style_delete(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_delete(&mut auth, &conn.0)?;
     let uid = auth.uid.unwrap();
 
     match style::delete(&conn.0, &uid, &id) {
         Ok(created) => Ok(Json(json!(created))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 
 #[get("/style/<id>")]
-fn style_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<String>> {
+fn style_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_get(&mut auth, &conn.0)?;
 
     match style::get(&conn.0, &auth.uid, &id) {
         Ok(style) => Ok(Json(json!(style))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/styles")]
-fn style_list_public(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+fn style_list_public(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_list(&mut auth, &conn.0)?;
 
     match style::list_public(&conn.0) {
         Ok(styles) => Ok(Json(json!(styles))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/styles/<user>")]
-fn style_list_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, user: i64) -> Result<Json, status::Custom<String>> {
+fn style_list_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, user: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_style_list(&mut auth, &conn.0)?;
 
     match auth.uid {
@@ -372,31 +372,31 @@ fn style_list_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::C
             if uid == user {
                 match style::list_user(&conn.0, &user) {
                     Ok(styles) => Ok(Json(json!(styles))),
-                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
                 }
             } else {
                 match style::list_user_public(&conn.0, &user) {
                     Ok(styles) => Ok(Json(json!(styles))),
-                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+                    Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
                 }
             }
         },
         _ => {
             match style::list_user_public(&conn.0, &user) {
                 Ok(styles) => Ok(Json(json!(styles))),
-                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
             }
         }
     }
 }
 
 #[get("/deltas")]
-fn delta_list(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) ->  Result<Json, status::Custom<String>> {
+fn delta_list(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) ->  Result<Json, status::Custom<Json>> {
     auth_rules.allows_delta_list(&mut auth, &conn.0)?;
 
     match delta::list_by_offset(&conn.0, None, None) {
         Ok(deltas) => Ok(Json(deltas)),
-        Err(err) => Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))))
     }
 }
 
@@ -409,11 +409,11 @@ struct DeltaList {
 }
 
 #[get("/deltas?<opts>")]
-fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, opts: DeltaList) ->  Result<Json, status::Custom<String>> {
+fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, opts: DeltaList) ->  Result<Json, status::Custom<Json>> {
     auth_rules.allows_delta_list(&mut auth, &conn.0)?;
 
     if opts.offset.is_some() && (opts.start.is_some() || opts.end.is_some()) {
-        return Err(status::Custom(HTTPStatus::BadRequest, String::from("Offset cannot be used with start or end")));
+        return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Offset cannot be used with start or end"))));
     }
 
     if opts.start.is_some() || opts.end.is_some() {
@@ -421,7 +421,7 @@ fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth:
             None => None,
             Some(start) => {
                 match start.parse() {
-                    Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Invalid start timestamp"))); },
+                    Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Invalid start timestamp")))); },
                     Ok(start) => Some(start)
                 }
             }
@@ -431,7 +431,7 @@ fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth:
             None => None,
             Some(end) => {
                 match end.parse() {
-                    Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Invalid end timestamp"))); },
+                    Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Invalid end timestamp")))); },
                     Ok(end) => Some(end)
                 }
             }
@@ -442,7 +442,7 @@ fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth:
                 return Ok(Json(deltas));
             },
             Err(err) => {
-                return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()));
+                return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))));
             }
         }
     } else if opts.offset.is_some() || opts.limit.is_some() {
@@ -451,103 +451,103 @@ fn delta_list_params(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth:
                 return Ok(Json(deltas));
             },
             Err(err) => {
-                return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()));
+                return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))));
             }
         }
     }
-    Err(status::Custom(HTTPStatus::BadRequest, String::from("Query Param Error")))
+    Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Query Param Error"))))
 }
 
 #[get("/delta/<id>")]
-fn delta(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) ->  Result<Json, status::Custom<String>> {
+fn delta(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) ->  Result<Json, status::Custom<Json>> {
     auth_rules.allows_delta_get(&mut auth, &conn.0)?;
 
     match delta::get_json(&conn.0, &id) {
         Ok(delta) => Ok(Json(delta)),
-        Err(err) => Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/data/bounds")]
-fn bounds_list(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+fn bounds_list(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_bounds_list(&mut auth, &conn.0)?;
 
     match bounds::list(&conn.0) {
         Ok(bounds) => Ok(Json(json!(bounds))),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/data/bounds/<bounds>")]
-fn bounds_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, bounds: String) -> Result<Stream<stream::PGStream>, status::Custom<String>> {
+fn bounds_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, bounds: String) -> Result<Stream<stream::PGStream>, status::Custom<Json>> {
     auth_rules.allows_bounds_list(&mut auth, &conn.0)?;
 
     match bounds::get(conn.0, bounds) {
         Ok(bs) => Ok(Stream::from(bs)),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/data/clone")]
-fn clone_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Stream<stream::PGStream>, status::Custom<String>> {
+fn clone_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Stream<stream::PGStream>, status::Custom<Json>> {
     auth_rules.allows_clone_get(&mut auth, &conn.0)?;
 
     match clone::get(conn.0) {
         Ok(clone) => Ok(Stream::from(clone)),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
 
 #[get("/data/features?<map>")]
-fn features_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<Stream<stream::PGStream>, status::Custom<String>> {
+fn features_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<Stream<stream::PGStream>, status::Custom<Json>> {
     auth_rules.allows_feature_get(&mut auth, &conn.0)?;
 
     let bbox: Vec<f64> = map.bbox.split(',').map(|s| s.parse().unwrap()).collect();
     match feature::get_bbox_stream(conn.0, bbox) {
         Ok(features) => Ok(Stream::from(features)),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(err.as_json())))
     }
 }
 
 #[get("/schema")]
-fn schema_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, schema: State<Option<serde_json::value::Value>>) -> Result<Json, status::Custom<String>> {
+fn schema_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, schema: State<Option<serde_json::value::Value>>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_schema_get(&mut auth, &conn.0)?;
 
     match schema.inner().clone() {
         Some(s) => Ok(Json(json!(s.clone()))),
-        None => Err(status::Custom(HTTPStatus::NotFound, String::from("No Schema Validation Enforced")))
+        None => Err(status::Custom(HTTPStatus::NotFound, Json(json!("No Schema Validation Enforced"))))
     }
 }
 
 #[get("/auth")]
-fn auth_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<String>> {
+fn auth_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_auth_get(&mut auth, &conn.0)?;
 
     Ok(Json(auth_rules.to_json()))
 }
 
 #[post("/data/features", format="application/json", data="<body>")]
-fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<String>> {
+fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_feature_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
 
     let mut fc = match body.parse::<GeoJson>() {
-        Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Body must be valid GeoJSON Feature"))); },
+        Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Body must be valid GeoJSON Feature")))); },
         Ok(geo) => match geo {
             GeoJson::FeatureCollection(fc) => fc,
-            _ => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Body must be valid GeoJSON FeatureCollection"))); }
+            _ => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Body must be valid GeoJSON FeatureCollection")))); }
         }
     };
 
     let delta_message = match fc.foreign_members {
-        None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("FeatureCollection Must have message property for delta"))); }
+        None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("FeatureCollection Must have message property for delta")))); }
         Some(ref members) => match members.get("message") {
             Some(message) => match message.as_str() {
                 Some(message) => String::from(message),
-                None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("FeatureCollection Must have message property for delta"))); }
+                None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("FeatureCollection Must have message property for delta")))); }
             },
-            None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("FeatureCollection Must have message property for delta"))); }
+            None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("FeatureCollection Must have message property for delta")))); }
         }
     };
 
@@ -561,7 +561,7 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
         Err(_) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not create delta"))); }
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not create delta")))); }
     };
 
     for feat in &mut fc.features {
@@ -569,7 +569,7 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
             Err(err) => {
                 trans.set_rollback();
                 trans.finish().unwrap();
-                return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string()));
+                return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
             },
             Ok(res) => {
                 if res.new != None {
@@ -582,7 +582,7 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
     if delta::modify(&delta_id, &trans, &fc, &uid).is_err() {
         trans.set_rollback();
         trans.finish().unwrap();
-        return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not create delta")));
+        return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not create delta"))));
     }
 
     match delta::finalize(&delta_id, &trans) {
@@ -593,39 +593,39 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()))
+            Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))))
         }
     }
 }
 
 #[get("/0.6/map?<map>")]
-fn xml_map(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<String, status::Custom<String>> {
+fn xml_map(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     let query: Vec<f64> = map.bbox.split(',').map(|s| s.parse().unwrap()).collect();
 
     let fc = match feature::get_bbox(&conn.0, query) {
         Ok(features) => features,
-        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string())) }
+        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json()))) }
     };
 
     let xml_str = match xml::from_features(&fc) {
         Ok(xml_str) => xml_str,
-        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string())) }
+        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(json!(err.to_string())))) }
     };
 
     Ok(xml_str)
 }
 
 #[put("/0.6/changeset/create", data="<body>")]
-fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, body: String) -> Result<String, status::Custom<String>> {
+fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, body: String) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
 
     let map = match xml::to_delta(&body) {
         Ok(map) => map,
-        Err(err) => { return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string())))); }
     };
 
     let trans = conn.0.transaction().unwrap();
@@ -635,7 +635,7 @@ fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))));
         }
     };
 
@@ -645,14 +645,14 @@ fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
 }
 
 #[put("/0.6/changeset/<id>/close")]
-fn xml_changeset_close(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, id: i64) -> Result<String, status::Custom<String>> {
+fn xml_changeset_close(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, id: i64) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     Ok(id.to_string())
 }
 
 #[put("/0.6/changeset/<delta_id>", data="<body>")]
-fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<String>> {
+fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<Json>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -678,7 +678,7 @@ fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))));
         }
     };
 
@@ -687,17 +687,17 @@ fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))));
         }
     };
 
     trans.commit().unwrap();
 
-    Err(status::Custom(HTTPStatus::Ok, delta_id.to_string()))
+    Err(status::Custom(HTTPStatus::Ok, Json(json!(delta_id))))
 }
 
 #[post("/0.6/changeset/<delta_id>/upload", data="<body>")]
-fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<String>> {
+fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<Json>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -720,7 +720,7 @@ fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
 
     let (mut fc, tree) = match xml::to_features(&body) {
         Ok(fctree) => fctree,
-        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string())); }
+        Err(err) => { return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(json!(err.to_string())))); }
     };
 
     let mut ids: HashMap<i64, feature::Response> = HashMap::new();
@@ -739,7 +739,7 @@ fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
             Err(err) => {
                 trans.set_rollback();
                 trans.finish().unwrap();
-                return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string()));
+                return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
             },
             Ok(feat_res) => {
                 if feat_res.old.unwrap_or(0) < 0 {
@@ -757,7 +757,7 @@ fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
         Err(_) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not format diffResult XML")));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not format diffResult XML"))));
         },
         Ok(diffres) => diffres
     };
@@ -767,25 +767,25 @@ fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
         Err(_) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not create delta")));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not create delta"))));
         }
     }
 
     match delta::finalize(&delta_id, &trans) {
         Ok (_) => {
             trans.commit().unwrap();
-            Err(status::Custom(HTTPStatus::Ok, diffres))
+            Err(status::Custom(HTTPStatus::Ok, Json(json!(diffres))))
         },
         Err(_) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not close delta")))
+            Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not close delta"))))
         }
     }
 }
 
 #[get("/capabilities")]
-fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
+fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("
@@ -803,7 +803,7 @@ fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::
 }
 
 #[get("/0.6/capabilities")]
-fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
+fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("
@@ -821,7 +821,7 @@ fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth
 }
 
 #[get("/0.6/user/details")]
-fn xml_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
+fn xml_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("
@@ -839,27 +839,27 @@ fn xml_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAu
 }
 
 #[post("/data/feature", format="application/json", data="<body>")]
-fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<String>> {
+fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, body: String) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_feature_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
 
     let mut feat = match body.parse::<GeoJson>() {
-        Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Body must be valid GeoJSON Feature"))); },
+        Err(_) => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Body must be valid GeoJSON Feature")))); },
         Ok(geo) => match geo {
             GeoJson::Feature(feat) => feat,
-            _ => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Body must be valid GeoJSON Feature"))); }
+            _ => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Body must be valid GeoJSON Feature")))); }
         }
     };
 
     let delta_message = match feat.foreign_members {
-        None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Feature Must have message property for delta"))); }
+        None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Feature Must have message property for delta")))); }
         Some(ref members) => match members.get("message") {
             Some(message) => match message.as_str() {
                 Some(message) => String::from(message),
-                None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Feature Must have message property for delta"))); }
+                None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Feature Must have message property for delta")))); }
             },
-            None => { return Err(status::Custom(HTTPStatus::BadRequest, String::from("Feature Must have message property for delta"))); }
+            None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Feature Must have message property for delta")))); }
         }
     };
 
@@ -872,7 +872,7 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
         Err(_) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not create delta")));
+            return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not create delta"))));
         }
     };
 
@@ -885,7 +885,7 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            return Err(status::Custom(HTTPStatus::ExpectationFailed, err.to_string()));
+            return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
         }
     }
 
@@ -898,7 +898,7 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
     if delta::modify(&delta_id, &trans, &fc, &uid).is_err() {
         trans.set_rollback();
         trans.finish().unwrap();
-        return Err(status::Custom(HTTPStatus::InternalServerError, String::from("Could not create delta")));
+        return Err(status::Custom(HTTPStatus::InternalServerError, Json(json!("Could not create delta"))));
     }
 
     match delta::finalize(&delta_id, &trans) {
@@ -909,18 +909,18 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
         Err(err) => {
             trans.set_rollback();
             trans.finish().unwrap();
-            Err(status::Custom(HTTPStatus::InternalServerError, err.to_string()))
+            Err(status::Custom(HTTPStatus::InternalServerError, Json(json!(err.to_string()))))
         }
     }
 }
 
 #[get("/data/feature/<id>")]
-fn feature_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<String, status::Custom<String>> {
+fn feature_get(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_feature_get(&mut auth, &conn.0)?;
 
     match feature::get(&conn.0, &id) {
         Ok(features) => Ok(geojson::GeoJson::from(features).to_string()),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(err.as_json())))
     }
 }
 
@@ -930,25 +930,25 @@ struct FeatureQuery {
 }
 
 #[get("/data/feature?<fquery>")]
-fn feature_query(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, fquery: FeatureQuery) -> Result<String, status::Custom<String>> {
+fn feature_query(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, fquery: FeatureQuery) -> Result<String, status::Custom<Json>> {
     auth_rules.allows_feature_get(&mut auth, &conn.0)?;
 
     if fquery.key.is_some() {
         match feature::query_by_key(&conn.0, &fquery.key.unwrap()) {
             Ok(features) => Ok(geojson::GeoJson::from(features).to_string()),
-            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(err.as_json())))
         }
     } else {
-        Err(status::Custom(HTTPStatus::BadRequest, String::from("At least 1 query parameter must be specified")))
+        Err(status::Custom(HTTPStatus::BadRequest, Json(json!("At least 1 query parameter must be specified"))))
     }
 }
 
 #[get("/data/feature/<id>/history")]
-fn feature_get_history(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<String>> {
+fn feature_get_history(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
     auth_rules.allows_feature_history(&mut auth, &conn.0)?;
 
     match delta::history(&conn.0, &id) {
         Ok(features) => Ok(Json(features)),
-        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, err.to_string()))
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,7 +599,7 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
 }
 
 #[get("/0.6/map?<map>")]
-fn xml_map(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<String, status::Custom<Json>> {
+fn xml_map(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, map: Map) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     let query: Vec<f64> = map.bbox.split(',').map(|s| s.parse().unwrap()).collect();
@@ -618,7 +618,7 @@ fn xml_map(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAut
 }
 
 #[put("/0.6/changeset/create", data="<body>")]
-fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, body: String) -> Result<String, status::Custom<Json>> {
+fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, body: String) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -645,14 +645,14 @@ fn xml_changeset_create(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
 }
 
 #[put("/0.6/changeset/<id>/close")]
-fn xml_changeset_close(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, id: i64) -> Result<String, status::Custom<Json>> {
+fn xml_changeset_close(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, id: i64) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     Ok(id.to_string())
 }
 
 #[put("/0.6/changeset/<delta_id>", data="<body>")]
-fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<Json>> {
+fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<String>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -697,7 +697,7 @@ fn xml_changeset_modify(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
 }
 
 #[post("/0.6/changeset/<delta_id>/upload", data="<body>")]
-fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<Json>> {
+fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, conn: DbConn, schema: State<Option<serde_json::value::Value>>, delta_id: i64, body: String) -> Result<Response<'static>, status::Custom<String>> {
     auth_rules.allows_osm_create(&mut auth, &conn.0)?;
 
     let uid = auth.uid.unwrap();
@@ -785,7 +785,7 @@ fn xml_changeset_upload(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth
 }
 
 #[get("/capabilities")]
-fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
+fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("
@@ -803,7 +803,7 @@ fn xml_capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::
 }
 
 #[get("/0.6/capabilities")]
-fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
+fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("
@@ -821,7 +821,7 @@ fn xml_06capabilities(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth
 }
 
 #[get("/0.6/user/details")]
-fn xml_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<Json>> {
+fn xml_user(conn: DbConn, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<String, status::Custom<String>> {
     auth_rules.allows_osm_get(&mut auth, &conn.0)?;
 
     Ok(String::from("

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -58,7 +58,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/schema").unwrap();
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -69,7 +69,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "No Schema Validation Enforced");
+            assert_eq!(resp.text().unwrap(), "\"No Schema Validation Enforced\"");
         }
 
         { //Create Point
@@ -93,7 +93,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1").unwrap();
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -109,7 +109,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/deltas").unwrap();
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -125,7 +125,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/delta/1").unwrap();
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -61,7 +61,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Body must be valid GeoJSON Feature");
+            assert_eq!(resp.text().unwrap(), "\"Body must be valid GeoJSON Feature\"");
         }
 
         { //Create Point - No Geometry
@@ -77,7 +77,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Body must be valid GeoJSON Feature");
+            assert_eq!(resp.text().unwrap(), "\"Body must be valid GeoJSON Feature\"");
         }
 
         { //Create Point - No Props
@@ -92,7 +92,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Body must be valid GeoJSON Feature");
+            assert_eq!(resp.text().unwrap(), "\"Body must be valid GeoJSON Feature\"");
         }
 
         { //Create Point - No Geom
@@ -108,7 +108,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Body must be valid GeoJSON Feature");
+            assert_eq!(resp.text().unwrap(), "\"Body must be valid GeoJSON Feature\"");
         }
 
         { //Create Point - No Props - Geom
@@ -127,7 +127,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Body must be valid GeoJSON Feature");
+            assert_eq!(resp.text().unwrap(), "\"Body must be valid GeoJSON Feature\"");
         }
 
         { //Create Point - No Message
@@ -144,7 +144,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Feature Must have message property for delta");
+            assert_eq!(resp.text().unwrap(), "\"Feature Must have message property for delta\"");
         }
 
         { //Create Point - Invalid version
@@ -164,7 +164,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Create Error: Should not have \'version\' property");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Creating a Point\",\"properties\":{},\"type\":\"Feature\",\"version\":15},\"id\":null,\"message\":\"Cannot have Version\"}");
         }
 
         { //Create Point
@@ -290,7 +290,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1 cannot restore an existing feature");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"restore\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":1,\"message\":\"Restore previously deleted point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":1},\"id\":1,\"message\":\"Feature Not In Deleted State\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -338,7 +338,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1 cannot restore an existing feature");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"restore\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":1,\"message\":\"Restore previously deleted point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":2},\"id\":1,\"message\":\"Feature Not In Deleted State\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -544,7 +544,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Restore Version Mismatch");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"restore\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":1,\"message\":\"Restore previously deleted point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":2},\"id\":1,\"message\":\"Restore Version Mismatch\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -565,7 +565,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Restore Error: Feature id: 1000 does not exist");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"restore\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":1000,\"message\":\"Restore previously deleted point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":2},\"id\":1000,\"message\":\"Feature Not Found\"}");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/key.rs
+++ b/tests/key.rs
@@ -286,7 +286,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Duplicate Key Value");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"key\":\"Q1233\",\"message\":\"Creating a Point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\"},\"id\":null,\"message\":\"Duplicate Key Value\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -347,7 +347,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Duplicate Key Value");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"modify\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":2,\"key\":\"12-34\",\"message\":\"Modify a point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":1},\"id\":2,\"message\":\"Duplicate Key Value\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -396,7 +396,7 @@ mod test {
                 .send()
                 .unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Duplicate Key Value");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"restore\",\"geometry\":{\"coordinates\":[1.0,1.0],\"type\":\"Point\"},\"id\":1,\"key\":\"Rando\",\"message\":\"Restore previously deleted point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\",\"version\":3},\"id\":1,\"message\":\"Duplicate Key Value\"}");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -76,7 +76,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Feature properties do not pass schema definition");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Creating a Point\",\"properties\":{\"number\":\"123\"},\"type\":\"Feature\"},\"id\":null,\"message\":\"Failed to Match Schema\"}");
         }
 
         { //Create Point Almost Passing Schema Validation
@@ -99,7 +99,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Feature properties do not pass schema definition");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Creating a Point\",\"properties\":{\"number\":\"123\",\"source\":\"Test Data\",\"street\":[{\"test\":\"123\"}]},\"type\":\"Feature\"},\"id\":null,\"message\":\"Failed to Match Schema\"}");
         }
 
         { //Create Point Passing Schema Validation
@@ -153,7 +153,7 @@ mod test {
                 .basic_auth("ingalls", Some("yeaheh"))
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), "Feature properties do not pass schema definition");
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"id\":-1,\"properties\":{\"number\":123,\"source\":\"Test Data\",\"street\":[{\"test\":\"123\"}]},\"type\":\"Feature\"},\"id\":-1,\"message\":\"Failed to Match Schema\"}");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -67,7 +67,7 @@ mod test {
 
         { //Get Style - No Auth
             let mut resp = reqwest::get("http://localhost:8000/api/style/1").unwrap();
-            assert_eq!(resp.text().unwrap(), "Style Not Found");
+            assert_eq!(resp.text().unwrap(), "\"Style Not Found\"");
             assert!(resp.status().is_client_error());
         }
 
@@ -87,7 +87,7 @@ mod test {
                 .basic_auth("ingalls", Some("yeaheh"))
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), r#"Style Not Found"#);
+            assert_eq!(resp.text().unwrap(), "\"Style Not Found\"");
             assert!(resp.status().is_client_error());
         }
 
@@ -147,7 +147,7 @@ mod test {
             let mut resp = client.delete("http://localhost:8000/api/style/1")
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 
@@ -167,7 +167,7 @@ mod test {
                 .basic_auth("ingalls", Some("yeaheh"))
                 .send()
                 .unwrap();
-            assert_eq!(resp.text().unwrap(), r#"Style Not Found"#);
+            assert_eq!(resp.text().unwrap(), "\"Style Not Found\"");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -108,7 +108,7 @@ mod test {
             let client = reqwest::Client::new();
             let mut resp = client.get("http://localhost:8000/api/tiles/1/0/0/regen").send().unwrap();
 
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
             assert!(resp.status().is_client_error());
         }
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -51,7 +51,7 @@ mod test {
 
         { //Create Username
             let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls&password=yeaheh&email=ingalls@protonmail.com").unwrap();
-            assert_eq!(resp.text().unwrap(), "Could not create user: duplicate key value violates unique constraint \"users_username_key\"");
+            assert_eq!(resp.text().unwrap(), "\"Could not create user: duplicate key value violates unique constraint \\\"users_username_key\\\"\"");
             assert!(resp.status().is_client_error());
         }
 
@@ -70,7 +70,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
         }
 
         { //Feature Upload with bad username
@@ -89,7 +89,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
         }
 
         { //Feature Upload with bad password
@@ -108,7 +108,7 @@ mod test {
                 .unwrap();
 
             assert!(resp.status().is_client_error());
-            assert_eq!(resp.text().unwrap(), "Not Authorized!");
+            assert_eq!(resp.text().unwrap(), "{\"code\":401,\"reason\":\"You must be logged in to access this resource\",\"status\":\"Not Authorized\"}");
         }
 
         { //Feature Upload with correct creds


### PR DESCRIPTION
At the moment import errors are a string value with no consistent formatting.

This standardizes import errors to the following format:

```js
{
    "id": 1, //falsy if creating a new feature
    "error": "I am a human readable error message",
    "feat": {
        //GeoJSON Feature that caused the error in the first place
    }
}
```

cc/ @mapbox/geocoding-gang 