### PR TITLE
Force Create

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ have a map containing the auth for each subkey.
 | `POST /api/data/feature(s)`           | `feature::create`         | `user`        | `user`, `admin`, `null`   |       |
 | `GET /api/data/feature/<id>`          | `feature::get`            | `public`      | All                       |       |
 | `GET /api/data/feature/<id>/history`  | `feature::history`        | `public`      | All                       |       |
+| `POST /api/data/feature(s) w/ `force` | `feature::force`          | `admin`       | `user`, `admin`, `null`   |       |
 | **Clone**                             | `clone`                   |               | `null`                    | 2     |
 | `GET /api/data/clone`                 | `clone::get`              | `user`        | All                       |       |
 | **Bounds**                            | `bounds`                  |               | `null`                    | 2     |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ server members.
 | `version` | The version of a given feature, starts at `1` for a newly created feature |
 | `action`  | Only used for uploads, the desired action to be performed. One of `create`, `modify`, `delete`, or `restore` |
 | `key`     | `[Optional]` A String containing a value that hecate will ensure remains unique accross all features. Can be a natural id (wikidata id, PID, etc), computed property hash, geometry hash etc. The specifics are left up to the client. Should an attempt at importing a Feature with a differing `id` but identical `key` be made, the feature with will be rejected, ensuring the uniqueness of the `key` values. By default this value will be `NULL`. Duplicate `NULL` values are allowed.
+| `force`   | `[Optional]` Boolean allowing a user to override version locking and force UPSERT a feature. Disabled by default |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ Downloaded Features will return the integer `id` of the feature, the current `ve
 A features being uploaded for creation must have the `action: create` property. Since an `id` and `version` have not yet been
 assigned they must be omitted. Should an `id` be included it will be ignored. Adding a `version` property will throw an error
 
+Optionally create actions can use the `force: true` option to perform an `UPSERT` like option. In this mode the uploader must
+specify the `key` value. Hecate will then `INSERT` the feature if the `key` value is new, if the `key` is already existing, the
+existing feature will be overwritten with the forced feature. Note that this mode ignores version checks and is therefore unsafe.
+
+Force Prerequisites
+- Disabled by default, must be explicitly enabled via [Custom Authentication](#custom-authentication)
+- Can only be performed on a feature with `action: create`
+- Must specify a valid `key`
+
 #### Modify Features
 
 ```JSON

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -269,6 +269,7 @@ impl ValidAuth for AuthDelta {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct AuthFeature {
+    pub force: Option<String>,
     pub create: Option<String>,
     pub get: Option<String>,
     pub history: Option<String>
@@ -277,6 +278,7 @@ pub struct AuthFeature {
 impl AuthFeature {
     fn new() -> Self {
         AuthFeature {
+            force: Some(String::from("user")),
             create: Some(String::from("user")),
             get: Some(String::from("public")),
             history: Some(String::from("public"))
@@ -287,6 +289,7 @@ impl AuthFeature {
 impl ValidAuth for AuthFeature {
     fn is_valid(&self) -> Result<bool, String> {
         is_auth("feature::create", &self.create)?;
+        is_auth("feature::force", &self.force)?;
         is_all("feature::get", &self.get)?;
         is_all("feature::history", &self.history)?;
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -278,7 +278,7 @@ pub struct AuthFeature {
 impl AuthFeature {
     fn new() -> Self {
         AuthFeature {
-            force: Some(String::from("user")),
+            force: Some(String::from("none")),
             create: Some(String::from("user")),
             get: Some(String::from("public")),
             history: Some(String::from("public"))

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -616,6 +616,13 @@ impl CustomAuth {
         }
     }
 
+    pub fn allows_feature_force(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
+        match &self.feature {
+            None => Err(not_authed()),
+            Some(feature) => auth_met(&feature.force, auth, &conn)
+        }
+    }
+
     pub fn allows_feature_get(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         match &self.feature {
             None => Err(not_authed()),

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -60,20 +60,20 @@ pub fn is_force(feat: &geojson::Feature) -> Result<bool, FeatureError> {
         Some(ref members) => match members.get("force") {
             Some(version) => {
                 if version.is_boolean() && version.as_bool().unwrap() == true {
-                    if get_action(&feat) != Action::Create {
-                        return Err(import_error(&feat, "force can only be used on create")); },
+                    if get_action(&feat)? != Action::Create {
+                        return Err(import_error(&feat, "force can only be used on create"));
                     }
-                
+
                     match get_key(&feat) {
                         None => {
-                            return Err(import_error(&feat, "force can only be used with a key value"));
+                            Err(import_error(&feat, "force can only be used with a key value"))
                         },
                         Some(_) => {
-                            return Ok(true);
+                            Ok(true)
                         }
                     }
                 } else {
-                    return Err(import_error(&feat, "force must be a boolean")); },
+                    Err(import_error(&feat, "force must be a boolean"))
                 }
             },
             None => Ok(false)
@@ -411,7 +411,7 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
         FROM (
             SELECT
                 deltas.id,
-                JSON_Array_Elements((deltas.features -> 'features')::JSON) AS feat 
+                JSON_Array_Elements((deltas.features -> 'features')::JSON) AS feat
             FROM
                 deltas
             WHERE

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -50,6 +50,22 @@ pub fn import_error(feat: &geojson::Feature, error: &str) -> FeatureError {
     }))
 }
 
+pub fn is_force(feat: &geojson::Feature) -> bool {
+    match feat.foreign_members {
+        None => false,
+        Some(ref members) => match members.get("force") {
+            Some(version) => {
+                if version.is_boolean() {
+                    version.as_bool().unwrap()
+                } else {
+                    false
+                }
+            },
+            None => false
+        }
+    }
+}
+
 pub fn del_version(feat: &mut geojson::Feature) {
     match feat.foreign_members {
         None => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,6 +565,10 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
     };
 
     for feat in &mut fc.features {
+        if feature::is_force(&feat) {
+            auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+        }
+
         match feature::action(&trans, &schema.inner(), &feat, &None) {
             Err(err) => {
                 trans.set_rollback();
@@ -875,6 +879,10 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
             _ => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Body must be valid GeoJSON Feature")))); }
         }
     };
+
+    if feature::is_force(&feat) {
+        auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+    }
 
     let delta_message = match feat.foreign_members {
         None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Feature Must have message property for delta")))); }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,9 +565,14 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
     };
 
     for feat in &mut fc.features {
-        if feature::is_force(&feat) {
-            auth_rules.allows_feature_force(&mut auth, &conn.0)?;
-        }
+        match feature::is_force(&feat) {
+            Err(err) => {
+                return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
+            },
+            Ok(_) => {
+                auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+            }
+        };
 
         match feature::action(&trans, &schema.inner(), &feat, &None) {
             Err(err) => {
@@ -880,9 +885,14 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
         }
     };
 
-    if feature::is_force(&feat) {
-        auth_rules.allows_feature_force(&mut auth, &conn.0)?;
-    }
+    match feature::is_force(&feat) {
+        Err(err) => {
+            return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
+        },
+        Ok(_) => {
+            auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+        }
+    };
 
     let delta_message = match feat.foreign_members {
         None => { return Err(status::Custom(HTTPStatus::BadRequest, Json(json!("Feature Must have message property for delta")))); }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,8 +569,10 @@ fn features_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, co
             Err(err) => {
                 return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
             },
-            Ok(_) => {
-                auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+            Ok(force) => {
+                if force {
+                    auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+                }
             }
         };
 
@@ -889,8 +891,10 @@ fn feature_action(mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, con
         Err(err) => {
             return Err(status::Custom(HTTPStatus::ExpectationFailed, Json(err.as_json())));
         },
-        Ok(_) => {
-            auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+        Ok(force) => {
+            if force {
+                auth_rules.allows_feature_force(&mut auth, &conn.0)?;
+            }
         }
     };
 

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -174,6 +174,7 @@ mod test {
                     "list": "user"
                 },
                 "feature": {
+                    "force": "user",
                     "create": "user",
                     "get": "user",
                     "history": "user"

--- a/tests/fixtures/auth.closed.json
+++ b/tests/fixtures/auth.closed.json
@@ -27,6 +27,7 @@
         "list": "user"
     },
     "feature": {
+        "force": "user",
         "create": "user",
         "get": "user",
         "history": "user"

--- a/tests/force.rs
+++ b/tests/force.rs
@@ -1,0 +1,240 @@
+extern crate reqwest;
+extern crate postgres;
+#[macro_use] extern crate serde_json;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use std::env;
+    use reqwest;
+    use serde_json;
+
+    #[test]
+    fn force() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
+        ]).spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+        thread::sleep(Duration::from_secs(1));
+
+        { //Create Username
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls&password=yeaheh&email=ingalls@protonmail.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Point - Force - Action Required
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "type": "Feature",
+                    "force": true,
+                    "message": "Testing Force Option",
+                    "properties": {
+                        "street": "Main Street"
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"force\":true,\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Testing Force Option\",\"properties\":{\"street\":\"Main Street\"},\"type\":\"Feature\"},\"id\":null,\"message\":\"Action Required\"}");
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Create Point - Force - Action Create required
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "type": "Feature",
+                    "action": "modify",
+                    "force": true,
+                    "message": "Testing Force Option",
+                    "properties": {
+                        "street": "Main Street"
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"modify\",\"force\":true,\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Testing Force Option\",\"properties\":{\"street\":\"Main Street\"},\"type\":\"Feature\"},\"id\":null,\"message\":\"force can only be used on create\"}");
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Create Point - Force - Must be used with key value
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "type": "Feature",
+                    "action": "create",
+                    "force": true,
+                    "message": "Testing Force Option",
+                    "properties": {
+                        "street": "Main Street"
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "{\"feature\":{\"action\":\"create\",\"force\":true,\"geometry\":{\"coordinates\":[0.0,0.0],\"type\":\"Point\"},\"message\":\"Testing Force Option\",\"properties\":{\"street\":\"Main Street\"},\"type\":\"Feature\"},\"id\":null,\"message\":\"force can only be used with a key value\"}");
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Create Point - Success
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "key": "1",
+                    "type": "Feature",
+                    "action": "create",
+                    "force": true,
+                    "message": "Testing Force Option",
+                    "properties": {
+                        "street": "Main Street"
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [0, 0]
+                    }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        {
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/data/feature/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "id": 1,
+                "key": "1",
+                "type": "Feature",
+                "version": 1,
+                "properties": {
+                    "street": "Main Street"
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 0.0, 0.0 ]
+                }
+            }));
+
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Point - Force Success
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "key": "1",
+                    "type": "Feature",
+                    "action": "create",
+                    "force": true,
+                    "message": "Testing Force Option",
+                    "properties": {
+                        "street": "I AM A NEW FEAT"
+                    },
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [1, 1]
+                    }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::ContentType::json())
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        {
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/data/feature/1")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "id": 1,
+                "key": "1",
+                "type": "Feature",
+                "version": 2,
+                "properties": {
+                    "street": "I AM A NEW FEAT"
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [ 1.0, 1.0 ]
+                }
+            }));
+
+            assert!(resp.status().is_success());
+        }
+
+        server.kill().unwrap();
+    }
+}


### PR DESCRIPTION
Add `force: true` option that can be used with`action: create` to force a feature to be UPSERTEd on a duplicate key error. 

This can only be used under the following condions
- Explicitly enabled via auth config (disabled by default)
- `action: create` is set (not allowed for `modify`, `delete` or `restore`)
- a `key: value` is specified.

cc/ @mattficke @lukasmartinelli @mapbox/geocoding-gang 