### PR TITLE
Remove Unwraps

### DIFF
--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -59,21 +59,23 @@ pub fn is_force(feat: &geojson::Feature) -> Result<bool, FeatureError> {
         None => Ok(false),
         Some(ref members) => match members.get("force") {
             Some(force) => {
-                if force.is_boolean() && force.as_bool().unwrap() == true {
-                    if get_action(&feat)? != Action::Create {
-                        return Err(import_error(&feat, "force can only be used on create"));
-                    }
-
-                    match get_key(&feat)? {
-                        None => {
-                            Err(import_error(&feat, "force can only be used with a key value"))
-                        },
-                        Some(_) => {
-                            Ok(true)
+                match force.as_bool() {
+                    Some(true) => {
+                        if get_action(&feat)? != Action::Create {
+                            return Err(import_error(&feat, "force can only be used on create"));
                         }
-                    }
-                } else {
-                    Err(import_error(&feat, "force must be a boolean"))
+
+                        match get_key(&feat)? {
+                            None => {
+                                Err(import_error(&feat, "force can only be used with a key value"))
+                            },
+                            Some(_) => {
+                                Ok(true)
+                            }
+                        }
+                    },
+                    Some(false) => Ok(false),
+                    None => Err(import_error(&feat, "force must be a boolean"))
                 }
             },
             None => Ok(false)

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -200,8 +200,14 @@ pub fn create(trans: &postgres::transaction::Transaction, schema: &Option<valico
 
     if !valid { return Err(import_error(&feat, "Failed to Match Schema")) };
 
-    let geom_str = serde_json::to_string(&geom).unwrap();
-    let props_str = serde_json::to_string(&props).unwrap();
+    let geom_str = match serde_json::to_string(&geom) {
+        Ok(geom) => geom,
+        Err(_) => { return Err(import_error(&feat, "Failed to stringify geometry")) }
+    };
+    let props_str = match serde_json::to_string(&props) {
+        Ok(props) => props,
+        Err(_) => { return Err(import_error(&feat, "Failed to stringify properties")) }
+    };
 
     let key = get_key(&feat)?;
 

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -377,7 +377,7 @@ pub fn query_by_key(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnect
             WHERE key = $1
         ) f;
     ", &[&key]) {
-        Some(res) => {
+        Ok(res) => {
             if res.len() != 1 { return Err(FeatureError::NotFound); }
 
             let feat: postgres::rows::Row = res.get(0);
@@ -392,7 +392,8 @@ pub fn query_by_key(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnect
 
             Ok(feat)
         },
-        Err(_) => { return Err(FeatureError::InvalidFeature); }
+        Err(_) => Err(FeatureError::InvalidFeature)
+    }
 }
 
 pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, id: &i64) -> Result<geojson::Feature, FeatureError> {
@@ -411,7 +412,7 @@ pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManage
             WHERE id = $1
         ) f;
     ", &[&id]) {
-        Some(res) = {
+        Ok(res) => {
             if res.len() != 1 { return Err(FeatureError::NotFound); }
 
             let feat: postgres::rows::Row = res.get(0);
@@ -426,7 +427,7 @@ pub fn get(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManage
 
             Ok(feat)
         },
-        Err(_) => { return Err(FeatureError::InvalidFeature); }
+        Err(_) => Err(FeatureError::InvalidFeature)
     }
 }
 


### PR DESCRIPTION
Replace `unwrap` statements with `match` & handled errors where possible.

No more unwrapping presents

![](https://3.bp.blogspot.com/-S5pE5GI5-9E/VYctm5Xtr6I/AAAAAAAAM5Q/OIHhS_m0zoU/s1600/How%2Bthe%2BGrinch%2BStole%2BChristmas%2B-%2BChuck%2BJones%2B%252861%2529.jpg)

cc/ @mapbox/geocoding-gang 