### PR TITLE
Read Replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,18 +286,22 @@ cargo run -- --database "<USER>:<PASSWORD>@<HOST>/<DATABASE>"
 cargo run -- --database "<USER>@<HOST>/<DATABASE>"
 ```
 
-Although optional, it is recommended that a second role is created with read-only privleges on the
-`geo` table. Users can then run queries using this account via the `/api/data/query` endpoint.
+A second read-only account should also be created with permissions to SELECT from the
+`geo` table. All query endpoints - query, clone, bbox, etc will use this readonly connection
 
-If this flag is not provided, the `query` endpoint will be disabled.
+If this flag is not provided, `query` endpoints will be disabled.
 
 Note: It is up to the DB Admin to ensure the permissions are limited in scope for this user. Hecate will
 expose access to this user via the query endpoint.
+
+If multiple instances of `database_read` are present, hecate will load balance accross the multiple read instances.
 
 ```bash
 cargo run -- --database_read "<USER>:<PASSWORD>@<HOST>/<DATABASE>"
 
 cargo run -- --database_read "<USER>@<HOST>/<DATABASE>"
+
+cargo run -- --database_read "<USER>@<HOST>/<DATABASE>" --database_read "<USER>@<HOST>/<DATABASE>"
 ```
 
 ### JSON Validation

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ cargo run -- --database "<USER>@<HOST>/<DATABASE>"
 ```
 
 A second read-only account should also be created with permissions to SELECT from the
-`geo` table. All query endpoints - query, clone, bbox, etc will use this readonly connection
+`geo` & `deltas` table. All query endpoints - query, clone, bbox, etc will use this readonly connection
+A sample implementation can be found in the `schema.sql` document
 
 If this flag is not provided, `query` endpoints will be disabled.
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -15,6 +15,7 @@ args:
         value_name: DATABASE_READ
         help: \[optional\] Specify the read user account for the database in format USER@HOST:PORT/DATABASE or USER:PASS@PORT/DATABASE
         takes_value: true
+        multiple: true
 
     - port:
         short: p

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -13,7 +13,7 @@ args:
     - database_read:
         long: database_read
         value_name: DATABASE_READ
-        help: \[optional\] Specify the read user account for the database in format USER@HOST:PORT/DATABASE or USER:PASS@PORT/DATABASE
+        help: \[optional\] Specify the read user connection(s) for the database in format USER@HOST:PORT/DATABASE or USER:PASS@PORT/DATABASE
         takes_value: true
         multiple: true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use rocket::response::{Response, status, Stream, NamedFile};
 use geojson::GeoJson;
 use rocket_contrib::Json;
 
-pub fn start(database: String, database_read: Option<String>, port: Option<u16>, schema: Option<serde_json::value::Value>, auth: Option<auth::CustomAuth>) {
+pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<u16>, schema: Option<serde_json::value::Value>, auth: Option<auth::CustomAuth>) {
     env_logger::init();
 
     let auth_rules: auth::CustomAuth = match auth {
@@ -64,7 +64,7 @@ pub fn start(database: String, database_read: Option<String>, port: Option<u16>,
 
     let db_read: DbRead = match database_read {
         None => DbRead::new(None),
-        Some(db) => DbRead::new(Some(init_pool(&db)))
+        Some(db) => DbRead::new(Some(init_pool(&db[0])))
     };
 
     let limits = Limits::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ use r2d2::{Pool, PooledConnection};
 use r2d2_postgres::{PostgresConnectionManager, TlsMode};
 use mvt::Encode;
 
+use rand::prelude::*;
+
 use std::io::{Cursor};
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
@@ -164,7 +166,10 @@ impl DbRead {
                 "reason": "No Database Read Connection"
             })))),
             Some(ref db_read) => {
-                match db_read.get(0).unwrap().get() {
+                let mut rng = thread_rng();
+                let db_read_it = rng.gen_range(0, db_read.len());
+
+                match db_read.get(db_read_it).unwrap().get() {
                     Ok(conn) => Ok(conn),
                     Err(_) => Err(status::Custom(HTTPStatus::ServiceUnavailable, Json(json!({
                         "code": 503,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ fn clone_query(conn: State<DbReadWrite>, read_conn: State<DbRead>, mut auth: aut
 fn clone_get(conn: State<DbReadWrite>, read_conn: State<DbRead>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Stream<stream::PGStream>, status::Custom<Json>> {
     auth_rules.allows_clone_get(&mut auth, &conn.get()?)?;
 
-    match clone::get(&read_conn.get()?) {
+    match clone::get(read_conn.get()?) {
         Ok(clone) => Ok(Stream::from(clone)),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(err.as_json())))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,10 +1144,11 @@ fn feature_query(conn: State<DbReadWrite>, read_conn: State<DbRead>, mut auth: a
 }
 
 #[get("/data/feature/<id>/history")]
-fn feature_get_history(conn: State<DbReadWrite>, read_conn: State<DbRead>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
-    auth_rules.allows_feature_history(&mut auth, &conn.get()?)?;
+fn feature_get_history(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
+    let conn = conn.get()?;
+    auth_rules.allows_feature_history(&mut auth, &conn)?;
 
-    match delta::history(&read_conn.get()?, &id) {
+    match delta::history(&conn, &id) {
         Ok(features) => Ok(Json(features)),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@ fn main() {
 
     let database = String::from(matched.value_of("database").unwrap_or("postgres@localhost:5432/hecate"));
 
-    let database_read = match matched.value_of("database_read") {
+    let database_read = match matched.values_of("database_read") {
         None => None,
-        Some(db_read) => Some(String::from(db_read))
+        Some(db_read) => Some(db_read.map(|db| String::from(db)).collect())
     };
 
     let schema: Option<serde_json::value::Value> = match matched.value_of("schema") {

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -131,4 +131,5 @@ DO $$DECLARE count int;
 
 CREATE ROLE hecate_read WITH LOGIN NOINHERIT;
 GRANT SELECT ON geo TO hecate_read;
+GRANT SELECT ON deltas TO hecate_read;
 -- -----------------------------------

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -36,7 +36,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //API Meta

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -46,7 +46,8 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap(),
+            "--database_read", "hecate_read@localhost:5432/hecate"
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 

--- a/tests/bounds.rs
+++ b/tests/bounds.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         {

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -42,7 +42,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -14,7 +14,7 @@ mod test {
     use serde_json;
 
     #[test]
-    fn features() {
+    fn deltas() {
         {
             let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
 

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/force.rs
+++ b/tests/force.rs
@@ -46,9 +46,9 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap(),
+            "--database_read", "hecate_read@localhost:5432/hecate"
         ]).spawn().unwrap();
-        thread::sleep(Duration::from_secs(1));
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/key.rs
+++ b/tests/key.rs
@@ -42,7 +42,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -44,7 +44,8 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--schema", env::current_dir().unwrap().join("tests/fixtures/source_schema.json").to_str().unwrap()
+            "--schema", env::current_dir().unwrap().join("tests/fixtures/source_schema.json").to_str().unwrap(),
+            "--database_read", "hecate_read@localhost:5432/hecate"
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username (ingalls)

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -36,7 +36,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
         
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/xml_download.rs
+++ b/tests/xml_download.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/xml_upload.rs
+++ b/tests/xml_upload.rs
@@ -40,7 +40,11 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").arg("run").spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--database_read", "hecate_read@localhost:5432/hecate"
+        ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username


### PR DESCRIPTION
- Allow load balancing across multiple read-only databases.
- Allow n number of `--database_read` args that will be load balanced accross
- Switch all query style endpoints to use database_read connections instead of readwrite.

cc/ @lukasmartinelli 