### PR TITLE
User APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,81 @@ curl -X GET \
 
 ---
 
+#### `GET` `/api/user/info`
+
+Allows an authenticated user to obtain information about their own account
+
+*Example*
+
+```bash
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/info'
+```
+
+---
+
+#### `GET` `/api/user/<id>` **ADMIN ONLY**
+
+Obtain information about any user in the system by their numeric User ID.
+
+Note the information returned is the same information that a user is able to
+lookup about themself with the `GET /api/user/info` endpoint.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `<id>`     | `REQUIRED` User ID to obtain user information of |
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/user/create?username=ingalls&password=yeaheh&email=ingalls@protonmail.com
+```
+
+---
+
+#### `PUT` `/api/user/<id>/admin` **ADMIN ONLY**
+
+Allows an admin to add another user to the admin pool.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `<id>`     | `REQUIRED` User ID to obtain user information of |
+
+*Example*
+
+```bash
+curl -X PUT \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/1/admin'
+```
+
+---
+
+#### `DELETE` `/api/user/<id>/admin` **ADMIN ONLY**
+
+Allows an existing admin to remove another user from the admin pool.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `<id>`     | `REQUIRED` User ID to obtain user information of |
+
+*Example*
+
+```bash
+curl -X DELETE \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/1/admin'
+```
+
+---
+
 <h3 align='center'>Downloading via Clone</h3>
 
 #### `GET` `/api/data/clone`

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ have a map containing the auth for each subkey.
 | `GET /api/tiles/<z>/<x>/<y>/regen`    | `mvt::regen`              | `user`        | All                       |       |
 | `GET /api/tiles/<z>/<x>/<y>/meta`     | `mvt::meta`               | `public`      | All                       |       |
 | **Users**                             | `user`                    |               | `null`                    | 2     |
+| `GET /api/users`                      | `user::list`              | `user`        | All                       |       |
 | `GET /api/user/info`                  | `user::info`              | `self`        | `self`, `admin`, `null`   |       |
 | `GET /api/create`                     | `user::create`            | `public`      | All                       |       |
 | `GET /api/create/session`             | `user::create_session`    | `self`        | `self`, `admin`, `null`   |       |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Built something cool that uses the Hecate API? Let us know!
 
 ## Build Environment
 
+<details>
+
 - Start by installing Rust from [rust-lang.org](https://www.rust-lang.org/en-US/), this will install the current stable version
 
 ```bash
@@ -111,6 +113,8 @@ You will now have an empty database which can be populated with your own data/us
 
 If you want to populate the database with sample data for testing, [ingalls/hecate-example](https://github.com/ingalls/hecate-example)
 has a selection of scripts to populate the database with test data.
+
+</details>
 
 ## Docker File (Coverage Tests)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ has a selection of scripts to populate the database with test data.
 
 ## Docker File (Coverage Tests)
 
+<details>
+
 The Docker file is designed to give the user a testing environment to easily run rust tests.
 
 Install docker and then run
@@ -128,7 +130,11 @@ docker build .
 docker run {{HASH FROM ABOVE}}
 ```
 
+</details>
+
 ## Feature Format
+
+<details>
 
 Hecate is designed as a GeoJSON first interchange and uses [standard GeoJSON](http://geojson.org/) with a couple additions
 and exceptions as outlined below.
@@ -284,6 +290,8 @@ Restore places the new given geometry/properties at the id specified. It does no
 must use the Feature History API to get the state before deletion and then perform the `restore` action.
 
 Note: Restore will throw an error if an feature still exists.
+
+</details>
 
 ## Server
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ server members.
 | `id`      | The unique integer `id` of a given feature. Note that all features get a unique id accross GeoJSON Geometry Type |
 | `version` | The version of a given feature, starts at `1` for a newly created feature |
 | `action`  | Only used for uploads, the desired action to be performed. One of `create`, `modify`, `delete`, or `restore` |
-| `key`     | `[Optional]` A String containing a value that hecate will ensure remains unique across all features. Can be a natural id (wikidata id, PID, etc), computed property hash, geometry hash etc. The specifics are left up to the client. Should an attempt at importing a Feature with a differing `id` but identical `key` be made, the feature with will be rejected, ensuring the uniqueness of the `key` values. By default this value will be `NULL`. Duplicate `NULL` values are allowed.
-| `force`   | `[Optional]` Boolean allowing a user to override version locking and force UPSERT a feature. Disabled by default |
+| `key`     | `Optional` A String containing a value that hecate will ensure remains unique across all features. Can be a natural id (wikidata id, PID, etc), computed property hash, geometry hash etc. The specifics are left up to the client. Should an attempt at importing a Feature with a differing `id` but identical `key` be made, the feature with will be rejected, ensuring the uniqueness of the `key` values. By default this value will be `NULL`. Duplicate `NULL` values are allowed.
+| `force`   | `Optional` Boolean allowing a user to override version locking and force UPSERT a feature. Disabled by default |
 
 ### Examples
 
@@ -566,7 +566,9 @@ curl -X GET 'http://localhost:8000/api/styles/1'
 User requesting their own styles will get public & private styles
 
 ```bash
-curl -X GET 'http://username:password@localhost:8000/api/styles/1'
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/styles/1'
 ```
 
 ---
@@ -582,7 +584,8 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"name": "Name of this particular style", "style": "Mapbox Style Object Here"}' \
-    'http://username:password@localhost:8000/api/style'
+    -u 'username:password' \
+    'http://localhost:8000/api/style'
 ```
 
 ---
@@ -642,7 +645,8 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"name": "New Name", "style": "New Mapbox Style Object Here"}' \
-    'http://username:password@localhost:8000/api/style/1'
+    -u 'username:password' \
+    'http://localhost:8000/api/style/1'
 ```
 
 ---
@@ -663,7 +667,9 @@ affect cloned styles that were made when it was public.
 *Example*
 
 ```bash
-curl -X POST 'http://username:password@localhost:8000/api/style/1/private'
+curl -X POST \
+    -u 'username:password' \
+    'http://localhost:8000/api/style/1/private'
 ```
 
 ---
@@ -684,7 +690,9 @@ and other users will be able to download, clone, and use it
 *Example*
 
 ```bash
-curl -X POST 'http://username:password@localhost:8000/api/style/1/public'
+curl -X POST \
+    -u 'username:password' \
+    'http://localhost:8000/api/style/1/public'
 ```
 
 ---
@@ -778,12 +786,32 @@ ensuring the tile isn't returned from the tile cache.
 *Example*
 
 ```bash
-curl -X GET 'http://username:password@localhost:8000/api/tiles/1/1/1/regen
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/tiles/1/1/1/regen
 ```
 
 ---
 
 <h3 align='center'>User Options</h3>
+
+#### `GET` `/api/users`
+
+Get a list of users (up to 100) or filter by a given user prefix.
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `filter` | `Optional` Desired search prefix for username |
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/users
+```
+
+---
 
 #### `GET` `/api/user/create`
 
@@ -812,7 +840,9 @@ Return a new session cookie and the `uid` given an Basic Authenticated request.
 *Example*
 
 ```bash
-curl -X GET 'http://username:password@localhost:8000/api/user/session
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/session
 ```
 
 ---
@@ -855,7 +885,7 @@ SELECT props FROM geo WHERE id = 1
 | Option          | Notes                                                        |
 | :-------------: | ------------------------------------------------------------ |
 | `query=<query>` | SQL Query to run against Geometries                          |
-| `limit=<limit>` | `[optional]` Optionally limit the number of returned results |
+| `limit=<limit>` | `Optional` Optionally limit the number of returned results |
 
 *Examples*
 
@@ -1006,7 +1036,8 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"action": "create", "message": "Random Changes", "type":"Feature","properties":{"shop": true},"geometry":{"type":"Point","coordinates":[0,0]}}' \
-    'http://username:password@localhost:8000/api/data/feature'
+    -u 'username:password' \
+    'http://localhost:8000/api/data/feature'
 ```
 
 ---
@@ -1029,7 +1060,8 @@ curl \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"type":"FeatureCollection","message":"A bunch of changes","features": [{"action": "create", "type":"Feature","properties":{"shop": true},"geometry":{"type":"Point","coordinates":[0,0]}}]}' \
-    'http://username:password@localhost:8000/api/data/features'
+    -u 'username:password' \
+    'http://localhost:8000/api/data/features'
 ```
 
 ---

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -234,6 +234,7 @@ impl ValidAuth for AuthMVT {
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct AuthUser {
     pub info: Option<String>,
+    pub list: Option<String>,
     pub create: Option<String>,
     pub create_session: Option<String>
 }
@@ -242,6 +243,7 @@ impl AuthUser {
     fn new() -> Self {
         AuthUser {
             info: Some(String::from("self")),
+            list: Some(String::from("user")),
             create: Some(String::from("public")),
             create_session: Some(String::from("self"))
         }
@@ -251,6 +253,7 @@ impl AuthUser {
 impl ValidAuth for AuthUser {
     fn is_valid(&self) -> Result<bool, String> {
         is_all("user::create", &self.create)?;
+        is_all("user::list", &self.list)?;
 
         is_self("user::create_session", &self.create_session)?;
         is_self("user::info", &self.info)?;
@@ -600,6 +603,13 @@ impl CustomAuth {
         match &self.mvt {
             None => Err(not_authed()),
             Some(mvt) => auth_met(&mvt.meta, auth, &conn)
+        }
+    }
+
+    pub fn allows_user_list(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
+        match &self.user {
+            None => Err(not_authed()),
+            Some(user) => auth_met(&user.list, auth, &conn)
         }
     }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -546,6 +546,11 @@ impl CustomAuth {
         json_auth
     }
 
+
+    pub fn is_admin(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
+        auth_met(&Some(String::from("admin")), auth, &conn)
+    }
+
     pub fn allows_server(&self, auth: &mut Auth, conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<bool, status::Custom<Json>> {
         auth_met(&self.server, auth, &conn)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
             mvt_regen,
             user_self,
             user_create,
+            user_set_admin,
+            user_delete_admin,
+            user_create,
             user_list,
             user_list_filter,
             user_create_session,
@@ -415,6 +418,30 @@ fn user_info(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<a
     auth_rules.is_admin(&mut auth, &conn)?;
 
     match user::info(&conn, &id) {
+        Ok(info) => { Ok(Json(json!(info))) },
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    }
+}
+
+#[put("/user/<id>/admin")]
+fn user_set_admin(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
+    let conn = conn.get()?;
+
+    auth_rules.is_admin(&mut auth, &conn)?;
+
+    match user::set_admin(&conn, &id) {
+        Ok(info) => { Ok(Json(json!(info))) },
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    }
+}
+
+#[delete("/user/<id>/admin")]
+fn user_delete_admin(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
+    let conn = conn.get()?;
+
+    auth_rules.is_admin(&mut auth, &conn)?;
+
+    match user::delete_admin(&conn, &id) {
         Ok(info) => { Ok(Json(json!(info))) },
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,6 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
             user_create,
             user_set_admin,
             user_delete_admin,
-            user_create,
             user_list,
             user_list_filter,
             user_create_session,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,6 +408,18 @@ fn user_list_filter(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: 
     }
 }
 
+#[get("/user/<id>")]
+fn user_info(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, id: i64) -> Result<Json, status::Custom<Json>> {
+    let conn = conn.get()?;
+
+    auth_rules.is_admin(&mut auth, &conn)?;
+
+    match user::info(&conn, &id) {
+        Ok(info) => { Ok(Json(json!(info))) },
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    }
+}
+
 #[get("/user/info")]
 fn user_self(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
     let conn = conn.get()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
             user_self,
             user_create,
             user_list,
+            user_list_filter,
             user_create_session,
             user_delete_session,
             style_create,
@@ -385,8 +386,19 @@ struct UserFilter {
     filter: Option<String>,
 }
 
+#[get("/users")]
+fn user_list(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>) -> Result<Json, status::Custom<Json>> {
+    let conn = conn.get()?;
+    auth_rules.allows_user_list(&mut auth, &conn)?;
+
+    match user::list(&conn, None) {
+        Ok(users) => Ok(Json(json!(users))),
+        Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    }
+}
+
 #[get("/users?<filter>")]
-fn user_list(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: UserFilter) -> Result<Json, status::Custom<Json>> {
+fn user_list_filter(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: UserFilter) -> Result<Json, status::Custom<Json>> {
     let conn = conn.get()?;
     auth_rules.allows_user_list(&mut auth, &conn)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
             mvt_meta,
             mvt_regen,
             user_self,
+            user_info,
             user_create,
             user_set_admin,
             user_delete_admin,
@@ -417,7 +418,7 @@ fn user_info(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<a
     auth_rules.is_admin(&mut auth, &conn)?;
 
     match user::info(&conn, &id) {
-        Ok(info) => { Ok(Json(json!(info))) },
+        Ok(info) => { Ok(Json(info)) },
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }
@@ -454,7 +455,7 @@ fn user_self(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<a
     let uid = auth.uid.unwrap();
 
     match user::info(&conn, &uid) {
-        Ok(info) => { Ok(Json(json!(info))) },
+        Ok(info) => { Ok(Json(info)) },
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -48,15 +48,16 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
 
     match conn.query("
         SELECT 
-            json_agg(row_to_json(row)) 
+            COALESCE(json_agg(row_to_json(row)), '[]'::JSON)
         FROM (
             SELECT
                 id,
+                access,
                 username
             FROM
                 users
             WHERE
-                username iLIKE $1
+                username ~ $1
             ORDER BY
                 username
             LIMIT 100

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -108,9 +108,9 @@ pub fn delete_admin(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnect
         }
     }
 }
-pub fn info(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64) -> Result<String, UserError> {
+pub fn info(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64) -> Result<serde_json::Value, UserError> {
     match conn.query("
-        SELECT row_to_json(u)::TEXT
+        SELECT row_to_json(u)
         FROM (
             SELECT
                 id,
@@ -122,10 +122,7 @@ pub fn info(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
             WHERE id = $1
         ) u
     ", &[ &uid ]) {
-        Ok(res) => {
-            let info: String = res.get(0).get(0);
-            Ok(info)
-        },
+        Ok(res) => Ok(res.get(0).get(0)),
         Err(err) => {
             match err.as_db() {
                 Some(e) => { Err(UserError::CreateTokenError(e.message.clone())) },

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -91,6 +91,23 @@ pub fn set_admin(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnection
     }
 }
 
+pub fn delete_admin(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64) -> Result<bool, UserError> {
+    match conn.query("
+        UPDATE users
+            SET
+                access = NULL
+            WHERE
+                id = $1
+    ", &[ &uid ]) {
+        Ok(_) => Ok(true),
+        Err(err) => {
+            match err.as_db() {
+                Some(e) => { Err(UserError::AdminError(e.message.clone())) },
+                _ => Err(UserError::AdminError(String::from("generic")))
+            }
+        }
+    }
+}
 pub fn info(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, uid: &i64) -> Result<String, UserError> {
     match conn.query("
         SELECT row_to_json(u)::TEXT

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -167,6 +167,7 @@ mod test {
                 },
                 "user": {
                     "info": "self",
+                    "list": "user",
                     "create": "public",
                     "create_session": "self"
                 },

--- a/tests/fixtures/auth.closed.json
+++ b/tests/fixtures/auth.closed.json
@@ -19,6 +19,7 @@
     },
     "user": {
         "info": "self",
+        "list": "user",
         "create": "public",
         "create_session": "self"
     },

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,5 +1,6 @@
 extern crate reqwest;
 extern crate postgres;
+#[macro_use] extern crate serde_json;
 
 #[cfg(test)]
 mod test {
@@ -10,6 +11,7 @@ mod test {
     use std::time::Duration;
     use std::thread;
     use reqwest;
+    use serde_json;
 
     #[test]
     fn users() {
@@ -145,6 +147,35 @@ mod test {
             assert_eq!(resp.text().unwrap(), "1");
             //TODO test for cookie existence - reqwest is currently working on adding better cookie
             //support
+        }
+
+        { //Create a new session given username & password
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/user/session")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+            assert_eq!(resp.text().unwrap(), "1");
+            //TODO test for cookie existence - reqwest is currently working on adding better cookie
+            //support
+        }
+
+        { //Test User Listing
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/users")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!([
+                                                   
+            ]));
         }
 
         server.kill().unwrap();

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -231,7 +231,7 @@ mod test {
             }));
         }
 
-        { // A non-admin cannot get user info about an arbitrary
+        { // A non-admin cannot get user info about an arbitrary user
             let client = reqwest::Client::new();
             let resp = client.get("http://localhost:8000/api/user/3")
                 .basic_auth("ingalls", Some("yeaheh"))
@@ -306,12 +306,22 @@ mod test {
 
         { // An admin can unset an admin
             let client = reqwest::Client::new();
-            let resp = client.delete("http://localhost:8000/api/user/3/admin")
-                .basic_auth("ingalls", Some("yeaheh"))
+            let resp = client.delete("http://localhost:8000/api/user/1/admin")
+                .basic_auth("admin_future", Some("yeaheh"))
                 .send()
                 .unwrap();
 
             assert!(resp.status().is_success());
+        }
+
+        { //Ensure admin was unset
+            let client = reqwest::Client::new();
+            let resp = client.get("http://localhost:8000/api/user/3")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_client_error());
         }
 
         server.kill().unwrap();

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -307,7 +307,7 @@ mod test {
         { // An admin can unset an admin
             let client = reqwest::Client::new();
             let resp = client.delete("http://localhost:8000/api/user/1/admin")
-                .basic_auth("admin_future", Some("yeaheh"))
+                .basic_auth("future_admin", Some("yeaheh"))
                 .send()
                 .unwrap();
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -212,6 +212,108 @@ mod test {
             assert_eq!(json_body, json!([]));
         }
 
+        { // Get info about my own account
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/user/info")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "id": 1,
+                "username": "ingalls",
+                "email": "ingalls@protonmail.com",
+                "meta": {}
+            }));
+        }
+
+        { // A non-admin cannot get user info about an arbitrary
+            let client = reqwest::Client::new();
+            let resp = client.get("http://localhost:8000/api/user/3")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_client_error());
+        }
+
+        { // A non-admin cannot set an admin
+            let client = reqwest::Client::new();
+            let resp = client.put("http://localhost:8000/api/user/1/admin")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_client_error());
+        }
+
+        { // A non-admin cannot unset an admin
+            let client = reqwest::Client::new();
+            let resp = client.delete("http://localhost:8000/api/user/1/admin")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_client_error());
+        }
+
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            conn.execute("
+                UPDATE users SET access = 'admin' WHERE id = 1;
+            ", &[]).unwrap();
+        }
+
+        { //Create Second User
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=future_admin&password=yeaheh&email=fake@example.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { // An admin can get user info about an arbitrary user
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/user/3")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "id": 3,
+                "username": "future_admin",
+                "email": "fake@example.com",
+                "meta": {}
+            }));
+        }
+
+        { // An admin can set an admin
+            let client = reqwest::Client::new();
+            let resp = client.put("http://localhost:8000/api/user/3/admin")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+        }
+
+        { // An admin can unset an admin
+            let client = reqwest::Client::new();
+            let resp = client.delete("http://localhost:8000/api/user/3/admin")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -173,9 +173,43 @@ mod test {
 
             let json_body: serde_json::value::Value = resp.json().unwrap();
 
-            assert_eq!(json_body, json!([
-                                                   
-            ]));
+            assert_eq!(json_body, json!([{
+                "id": 1,
+                "access": null,
+                "username": "ingalls",
+            }]));
+        }
+
+        { //Test User Listing w/ Filtering
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/users?filter=in")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!([{
+                "id": 1,
+                "access": null,
+                "username": "ingalls",
+            }]));
+        }
+
+        { //Test User Listing w/ Filtering - no match
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/users?filter=kp")
+                .basic_auth("ingalls", Some("yeaheh"))
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!([]));
         }
 
         server.kill().unwrap();


### PR DESCRIPTION
This PR introduces several new user APIs and adds some critical missing user management features.

## Admin

- [x] Add set_admin function in users mod
- [x] Add an endpoint for allowing an admin to add admins who can add more admins

## User Listing

- [x] Allow listing of up to `100` users with the `api/users` endpoint
- [x] Allow searching for a given user with the `apu/users?filter=` endpoint

## Pending

- Add a way to create an initial admin account when theserver connects to an empty database


Closes: https://github.com/mapbox/Hecate/issues/85

cc/ @mapbox/search 