### PR TITLE
Add admin redirect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,8 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
             index
         ])
         .mount("/admin", routes![
-            staticsrv
+            staticsrv,
+            staticsrvredirect
         ])
         .mount("/api", routes![
             server,
@@ -292,6 +293,11 @@ fn meta_set(mut auth: auth::Auth, conn: State<DbReadWrite>, auth_rules: State<au
         Ok(_) => Ok(Json(json!(true))),
         Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
     }
+}
+
+#[get("/")]
+fn staticsrvredirect() -> rocket::response::Redirect {
+    rocket::response::Redirect::to("/admin/index.html")
 }
 
 #[get("/<file..>")]


### PR DESCRIPTION
Small papercut bug that was driving me crazy

Previously navigating to `/admin` or `/admin/` would result in a 404 since a specific file was not requested.

This PR automatically redirects these URLs to `/admin/index.html`

cc/ @mapbox/search 