### PR TITLE
Configurable Workers

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -23,6 +23,12 @@ args:
         value_name: PORT
         help: \[optional\] Specify a custom port
 
+    - workers:
+        short: w
+        long: workers
+        value_name: WORKERS
+        help: \[optional\] Number of concurrent connections the server will actively respond to at a given time
+
     - schema:
         short: s
         long: schema

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,14 @@ use rocket::response::{Response, status, Stream, NamedFile};
 use geojson::GeoJson;
 use rocket_contrib::Json;
 
-pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<u16>, schema: Option<serde_json::value::Value>, auth: Option<auth::CustomAuth>) {
+pub fn start(
+    database: String,
+    database_read: Option<Vec<String>>,
+    port: Option<u16>,
+    workers: Option<u16>,
+    schema: Option<serde_json::value::Value>,
+    auth: Option<auth::CustomAuth>
+) {
     env_logger::init();
 
     let auth_rules: auth::CustomAuth = match auth {
@@ -80,7 +87,7 @@ pub fn start(database: String, database_read: Option<Vec<String>>, port: Option<
         .log_level(LoggingLevel::Debug)
         .port(port.unwrap_or(8000))
         .limits(limits)
-        .workers(12)
+        .workers(workers.unwrap_or(12))
         .unwrap();
 
     rocket::custom(config, true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,21 @@ fn main() {
     };
 
     let port: Option<u16> = match matched.value_of("port") {
-        Some(port) => {
-            Some(port.parse().unwrap())
-        },
+        Some(port) => Some(port.parse().unwrap()),
         None => None
     };
 
-    hecate::start(database, database_read, port, schema, auth);
+    let workers: Option<u16> = match matched.value_of("workers") {
+        Some(workers) => Some(workers.parse().unwrap()),
+        None => None
+    };
+
+    hecate::start(
+        database,
+        database_read,
+        port,
+        workers,
+        schema,
+        auth
+    );
 }


### PR DESCRIPTION
By default Hecate will spin up 12 parallel workers to handle tasks.

This exposes a `--worker` flag to customize this value to allow greater concurrency on a given hecate worker.

cc/ @mapbox/search 