### PR TITLE
Default Read Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ cargo run
 
 ### Database
 
-By default hecate will attempt to connect to `postgres@localhost:5432/hecate`.
+By default hecate will attempt to connect to `hecate@localhost:5432/hecate` for write
+operations and simultaneously connect to `hecate_read@localhost:5432/hecate` for
+read only operations.
 
 Note that only postgres/postgis backed databases are currently supported.
 
@@ -326,8 +328,6 @@ cargo run -- --database "<USER>@<HOST>/<DATABASE>"
 A second read-only account should also be created with permissions to SELECT from the
 `geo` & `deltas` table. All query endpoints - query, clone, bbox, etc will use this readonly connection
 A sample implementation can be found in the `schema.sql` document
-
-If this flag is not provided, `query` endpoints will be disabled.
 
 Note: It is up to the DB Admin to ensure the permissions are limited in scope for this user. Hecate will
 expose access to this user via the query endpoint.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ use rocket_contrib::Json;
 
 pub fn start(
     database: String,
-    database_read: Option<Vec<String>>,
+    database_read: Vec<String>,
     port: Option<u16>,
     workers: Option<u16>,
     schema: Option<serde_json::value::Value>,
@@ -73,10 +73,7 @@ pub fn start(
         }
     };
 
-    let db_read: DbRead = match database_read {
-        None => DbRead::new(None),
-        Some(dbs) => DbRead::new(Some(dbs.iter().map(|db| init_pool(&db)).collect()))
-    };
+    let db_read: DbRead = DbRead::new(Some(dbs.iter().map(|db| init_pool(&db)).collect()));
 
     let limits = Limits::new()
         .limit("json", 20971520)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub fn start(
         }
     };
 
-    let db_read: DbRead = DbRead::new(Some(dbs.iter().map(|db| init_pool(&db)).collect()));
+    let db_read: DbRead = DbRead::new(Some(database_read.iter().map(|db| init_pool(&db)).collect()));
 
     let limits = Limits::new()
         .limit("json", 20971520)

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ fn main() {
     let database = String::from(matched.value_of("database").unwrap_or("postgres@localhost:5432/hecate"));
 
     let database_read = match matched.values_of("database_read") {
-        None => None,
-        Some(db_read) => Some(db_read.map(|db| String::from(db)).collect())
+        None => vec![String::from("hecate_read@localhost:5432/hecate")],
+        Some(db_read) => db_read.map(|db| String::from(db)).collect()
     };
 
     let schema: Option<serde_json::value::Value> = match matched.value_of("schema") {

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -123,7 +123,6 @@ CREATE OR REPLACE FUNCTION modify_geo(TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT)
 
 COMMIT;
 
-
 -- ------- Hecate Read User ----------
 DO $$DECLARE count int;
     BEGIN
@@ -139,4 +138,19 @@ DO $$DECLARE count int;
 CREATE ROLE hecate_read WITH LOGIN NOINHERIT;
 GRANT SELECT ON geo TO hecate_read;
 GRANT SELECT ON deltas TO hecate_read;
+-- -----------------------------------
+
+-- ------- Hecate User ---------------
+DO $$DECLARE count int;
+    BEGIN
+        SELECT count(*) INTO count FROM pg_roles WHERE rolname = 'hecate';
+
+        IF count > 0 THEN
+            EXECUTE 'REVOKE ALL PRIVILEGES ON DATABASE hecate FROM hecate;';
+            EXECUTE 'DROP ROLE IF EXISTS hecate;';
+        END IF;
+    END$$;
+
+CREATE ROLE hecate WITH LOGIN NOINHERIT;
+GRANT ALL PRIVILEGES ON DATABASE hecate TO hecate;
 -- -----------------------------------

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -36,11 +36,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //API Meta

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -46,8 +46,7 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap(),
-            "--database_read", "hecate_read@localhost:5432/hecate"
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 

--- a/tests/bounds.rs
+++ b/tests/bounds.rs
@@ -42,11 +42,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -42,11 +42,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/feature.rs
+++ b/tests/feature.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/force.rs
+++ b/tests/force.rs
@@ -46,8 +46,7 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap(),
-            "--database_read", "hecate_read@localhost:5432/hecate"
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/key.rs
+++ b/tests/key.rs
@@ -42,11 +42,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -46,7 +46,6 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--database_read", "hecate_read@localhost:5432/hecate",
             "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.closed.json").to_str().unwrap()
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -44,8 +44,7 @@ mod test {
         let mut server = Command::new("cargo").args(&[
             "run",
             "--",
-            "--schema", env::current_dir().unwrap().join("tests/fixtures/source_schema.json").to_str().unwrap(),
-            "--database_read", "hecate_read@localhost:5432/hecate"
+            "--schema", env::current_dir().unwrap().join("tests/fixtures/source_schema.json").to_str().unwrap()
         ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 

--- a/tests/stats.rs
+++ b/tests/stats.rs
@@ -42,11 +42,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/styles.rs
+++ b/tests/styles.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username (ingalls)

--- a/tests/tiles.rs
+++ b/tests/tiles.rs
@@ -36,11 +36,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -42,11 +42,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
         
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/xml_download.rs
+++ b/tests/xml_download.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username

--- a/tests/xml_upload.rs
+++ b/tests/xml_upload.rs
@@ -40,11 +40,7 @@ mod test {
             conn.batch_execute(&*table_sql).unwrap();
         }
 
-        let mut server = Command::new("cargo").args(&[
-            "run",
-            "--",
-            "--database_read", "hecate_read@localhost:5432/hecate"
-        ]).spawn().unwrap();
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
         thread::sleep(Duration::from_secs(1));
 
         { //Create Username


### PR DESCRIPTION
Removes a major pain point of getting a dev environment set up.

- No longer require a `--database_read` flag to enable query operations
- Create `hecate` user that is used by default and locked only to the `hecate` database instead of defaulting to the `postgres` user
- Use the `hecate_read` user by default
- Update README

cc/ @mapbox/search 