### PR TITLE
Filter consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,8 @@ Get a list of users (up to 100) or filter by a given user prefix.
 
 | Option     | Notes |
 | :--------: | ----- |
-| `filter` | `Optional` Desired search prefix for username |
+| `filter` | `Optional` Desired search prefix for username              |
+| `limit`  | `Optional` Optionally limit the number of returned results |
 
 *Example*
 
@@ -1069,7 +1070,7 @@ SELECT props FROM geo WHERE id = 1
 | Option          | Notes                                                        |
 | :-------------: | ------------------------------------------------------------ |
 | `query=<query>` | SQL Query to run against Geometries                          |
-| `limit=<limit>` | `Optional` Optionally limit the number of returned results |
+| `limit=<limit>` | `Optional` Optionally limit the number of returned results   |
 
 *Examples*
 
@@ -1091,9 +1092,17 @@ curl -X GET 'http://localhost:8000/api/data/query?query=SELECT%20props%20FROM%20
 
 Boundaries allow downloading data via a set of pre-determined boundary files.
 
-#### `GET` `/api/data/bounds/`
+#### `GET` `/api/data/bounds`
 
 Return an array of possible boundary files with which data can be extracted from the server with
+
+
+*Options*
+
+| Option     | Notes |
+| :--------: | ----- |
+| `filter` | `Optional` Desired search prefix for username              |
+| `limit`  | `Optional` Optionally limit the number of returned results |
 
 *Example*
 

--- a/src/bounds/mod.rs
+++ b/src/bounds/mod.rs
@@ -69,7 +69,8 @@ pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     match conn.query("
         SELECT name
             FROM bounds
-            WHERE bounds iLIKE $1||'%'
+            WHERE name iLIKE $1||'%'
+            ORDER BY name
             LIMIT $2::SmallInt
     ", &[ &prefix, &limit ]) {
         Ok(rows) => {
@@ -94,6 +95,7 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
     match conn.query("
         SELECT name
         FROM bounds
+        ORDER BY name
         LIMIT $1::SmallInt
     ", &[ &limit ]) {
         Ok(rows) => {

--- a/src/bounds/mod.rs
+++ b/src/bounds/mod.rs
@@ -60,7 +60,12 @@ pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn search(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, prefix: &String, limit: &Option<i8>) -> Result<Vec<String>, BoundsError> {
+pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, prefix: &String, limit: &Option<i8>) -> Result<Vec<String>, BoundsError> {
+    let limit: i8 = match limit {
+        None => 100,
+        Some(limit) => if *limit > 100 { 100 } else { *limit }
+    };
+
     match conn.query("
         SELECT name
             FROM bounds
@@ -85,10 +90,12 @@ pub fn search(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<Vec<String>, BoundsError> {
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i8>) -> Result<Vec<String>, BoundsError> {
     match conn.query("
-        SELECT name FROM bounds
-    ", &[]) {
+        SELECT name
+        FROM bounds
+        LIMIT $1
+    ", &[ &limit ]) {
         Ok(rows) => {
             let mut names = Vec::<String>::new();
 

--- a/src/bounds/mod.rs
+++ b/src/bounds/mod.rs
@@ -60,8 +60,8 @@ pub fn delete(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, prefix: &String, limit: &Option<i8>) -> Result<Vec<String>, BoundsError> {
-    let limit: i8 = match limit {
+pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, prefix: &String, limit: &Option<i16>) -> Result<Vec<String>, BoundsError> {
+    let limit: i16 = match limit {
         None => 100,
         Some(limit) => if *limit > 100 { 100 } else { *limit }
     };
@@ -70,7 +70,7 @@ pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
         SELECT name
             FROM bounds
             WHERE bounds iLIKE $1||'%'
-            LIMIT $2
+            LIMIT $2::SmallInt
     ", &[ &prefix, &limit ]) {
         Ok(rows) => {
             let mut names = Vec::<String>::new();
@@ -90,11 +90,11 @@ pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i8>) -> Result<Vec<String>, BoundsError> {
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i16>) -> Result<Vec<String>, BoundsError> {
     match conn.query("
         SELECT name
         FROM bounds
-        LIMIT $1
+        LIMIT $1::SmallInt
     ", &[ &limit ]) {
         Ok(rows) => {
             let mut names = Vec::<String>::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl DbReadWrite {
 #[derive(FromForm, Debug)]
 struct Filter {
     filter: Option<String>,
-    limit: Option<i8>
+    limit: Option<i16>
 }
 
 #[catch(401)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ fn users(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth:
     let conn = conn.get()?;
     auth_rules.allows_user_list(&mut auth, &conn)?;
 
-    match filter.filter {
+    match &filter.filter {
         Some(search) => {
             match user::filter(&conn, &search, &filter.limit) {
                 Ok(users) => Ok(Json(json!(users))),
@@ -757,7 +757,7 @@ fn bounds(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth
 
     auth_rules.allows_bounds_list(&mut auth, &conn)?;
 
-    match filter.filter {
+    match &filter.filter {
         Some(search) => {
             match bounds::filter(&conn, &search, &filter.limit) {
                 Ok(bounds) => Ok(Json(json!(bounds))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,13 +112,12 @@ pub fn start(
             mvt_meta,
             mvt_wipe,
             mvt_regen,
+            users,
             user_self,
             user_info,
             user_create,
             user_set_admin,
             user_delete_admin,
-            user_list,
-            user_filter,
             user_create_session,
             user_delete_session,
             style_create,
@@ -137,8 +136,7 @@ pub fn start(
             feature_query,
             feature_get_history,
             features_get,
-            bounds_list,
-            bounds_filter,
+            bounds,
             bounds_stats,
             bounds_get,
             bounds_set,
@@ -416,19 +414,22 @@ fn user_create(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State
 }
 
 #[get("/users?<filter..>")]
-fn user_filter(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: Form<Filter>) -> Result<Json<serde_json::Value>, status::Custom<Json<serde_json::Value>>> {
+fn users(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: Form<Filter>) -> Result<Json<serde_json::Value>, status::Custom<Json<serde_json::Value>>> {
     let conn = conn.get()?;
     auth_rules.allows_user_list(&mut auth, &conn)?;
 
-    if filter.filter.is_some() {
-        match user::filter(&conn, &filter.filter) {
-            Ok(users) => Ok(Json(json!(users))),
-            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
-        }
-    } else {
-        match user::list(&conn) {
-            Ok(users) => Ok(Json(json!(users))),
-            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    match filter.filter {
+        Some(search) => {
+            match user::filter(&conn, &search, &filter.limit) {
+                Ok(users) => Ok(Json(json!(users))),
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+            }
+        },
+        None => {
+            match user::list(&conn, &filter.limit) {
+                Ok(users) => Ok(Json(json!(users))),
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+            }
         }
     }
 }
@@ -751,20 +752,23 @@ fn delta(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth:
 }
 
 #[get("/data/bounds?<filter..>")]
-fn bounds_filter(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: Form<Filter>) -> Result<Json<serde_json::Value>, status::Custom<Json<serde_json::Value>>> {
+fn bounds(conn: State<DbReadWrite>, mut auth: auth::Auth, auth_rules: State<auth::CustomAuth>, filter: Form<Filter>) -> Result<Json<serde_json::Value>, status::Custom<Json<serde_json::Value>>> {
     let conn = conn.get()?;
 
     auth_rules.allows_bounds_list(&mut auth, &conn)?;
 
-    if filter.filter.is_some() {
-        match bounds::search(&conn, &filter.filter, &filter.limit) {
-            Ok(bounds) => Ok(Json(json!(bounds))),
-            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
-        }
-    } else {
-        match bounds::list(&conn) {
-            Ok(bounds) => Ok(Json(json!(bounds))),
-            Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+    match filter.filter {
+        Some(search) => {
+            match bounds::filter(&conn, &search, &filter.limit) {
+                Ok(bounds) => Ok(Json(json!(bounds))),
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+            }
+        },
+        None => {
+            match bounds::list(&conn, &filter.limit) {
+                Ok(bounds) => Ok(Json(json!(bounds))),
+                Err(err) => Err(status::Custom(HTTPStatus::BadRequest, Json(json!(err.to_string()))))
+            }
         }
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -18,6 +18,7 @@ pub struct PGStream {
     cursor: String,
     pending: Option<Vec<u8>>,
     trans: postgres::transaction::Transaction<'static>,
+    #[allow(dead_code)]
     conn: Box<r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>>
 }
 

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -43,7 +43,12 @@ pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>) -> Result<serde_json::Value, UserError> {
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i8>) -> Result<serde_json::Value, UserError> {
+    let limit: i8 = match limit {
+        None => 100,
+        Some(limit) => if *limit > 100 { 100 } else { *limit }
+    };
+
     match conn.query("
         SELECT 
             COALESCE(json_agg(row_to_json(row)), '[]'::JSON)
@@ -56,9 +61,9 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
                 users
             ORDER BY
                 username
-            LIMIT 100
+            LIMIT $1
         ) row;
-    ", &[ ]) {
+    ", &[ &limit ]) {
         Ok(rows) => Ok(rows.get(0).get(0)),
         Err(err) => {
             match err.as_db() {
@@ -69,7 +74,12 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
     }
 }
 
-pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, filter: &String) -> Result<serde_json::Value, UserError> {
+pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, filter: &String, limit: &Option<i8>) -> Result<serde_json::Value, UserError> {
+    let limit: i8 = match limit {
+        None => 100,
+        Some(limit) => if *limit > 100 { 100 } else { *limit }
+    };
+
     match conn.query("
         SELECT 
             COALESCE(json_agg(row_to_json(row)), '[]'::JSON)
@@ -84,9 +94,9 @@ pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
                 username ~ $1
             ORDER BY
                 username
-            LIMIT 100
+            LIMIT $2
         ) row;
-    ", &[ &filter ]) {
+    ", &[ &filter, &limit ]) {
         Ok(rows) => Ok(rows.get(0).get(0)),
         Err(err) => {
             match err.as_db() {

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -43,8 +43,8 @@ pub fn create(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
     }
 }
 
-pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i8>) -> Result<serde_json::Value, UserError> {
-    let limit: i8 = match limit {
+pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, limit: &Option<i16>) -> Result<serde_json::Value, UserError> {
+    let limit: i16 = match limit {
         None => 100,
         Some(limit) => if *limit > 100 { 100 } else { *limit }
     };
@@ -61,7 +61,7 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
                 users
             ORDER BY
                 username
-            LIMIT $1
+            LIMIT $1::SmallInt
         ) row;
     ", &[ &limit ]) {
         Ok(rows) => Ok(rows.get(0).get(0)),
@@ -74,8 +74,8 @@ pub fn list(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManag
     }
 }
 
-pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, filter: &String, limit: &Option<i8>) -> Result<serde_json::Value, UserError> {
-    let limit: i8 = match limit {
+pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, filter: &String, limit: &Option<i16>) -> Result<serde_json::Value, UserError> {
+    let limit: i16 = match limit {
         None => 100,
         Some(limit) => if *limit > 100 { 100 } else { *limit }
     };
@@ -94,7 +94,7 @@ pub fn filter(conn: &r2d2::PooledConnection<r2d2_postgres::PostgresConnectionMan
                 username ~ $1
             ORDER BY
                 username
-            LIMIT $2
+            LIMIT $2::SmallInt
         ) row;
     ", &[ &filter, &limit ]) {
         Ok(rows) => Ok(rows.get(0).get(0)),

--- a/tests/bounds.rs
+++ b/tests/bounds.rs
@@ -76,6 +76,40 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Set alt Bounds
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/bounds/alt")
+                .body(r#"{
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -77.13363647460938, 38.83542884007305 ], [ -76.96403503417969, 38.83542884007305 ], [ -76.96403503417969, 38.974891064341726 ], [ -77.13363647460938, 38.974891064341726 ], [ -77.13363647460938, 38.83542884007305 ] ] ] ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Set alt2 Bounds
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/bounds/alt2")
+                .body(r#"{
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ -77.13363647460938, 38.83542884007305 ], [ -76.96403503417969, 38.83542884007305 ], [ -76.96403503417969, 38.974891064341726 ], [ -77.13363647460938, 38.974891064341726 ], [ -77.13363647460938, 38.83542884007305 ] ] ] ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeaheh"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
         { //Create Point Inside of Bounds
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/feature")
@@ -118,7 +152,34 @@ mod test {
             let mut resp = reqwest::get("http://localhost:8000/api/data/bounds").unwrap();
 
             let json_body: serde_json::value::Value = resp.json().unwrap();
-            assert_eq!(json_body, json!(["dc"]));
+            assert_eq!(json_body, json!(["alt", "alt2", "dc"]));
+
+            assert!(resp.status().is_success());
+        }
+
+        { //List Bounds w/ Limit
+            let mut resp = reqwest::get("http://localhost:8000/api/data/bounds?limit=2").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!(["alt", "alt2"]));
+
+            assert!(resp.status().is_success());
+        }
+
+        { //List Bounds w/ Filter
+            let mut resp = reqwest::get("http://localhost:8000/api/data/bounds?filter=alt").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!(["alt", "alt2"]));
+
+            assert!(resp.status().is_success());
+        }
+
+        { //List Bounds w/ Filter & Limit
+            let mut resp = reqwest::get("http://localhost:8000/api/data/bounds?filter=alt&limit=1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!(["alt"]));
 
             assert!(resp.status().is_success());
         }
@@ -224,7 +285,7 @@ mod test {
             let mut resp = reqwest::get("http://localhost:8000/api/data/bounds").unwrap();
 
             let json_body: serde_json::value::Value = resp.json().unwrap();
-            assert_eq!(json_body, json!([]));
+            assert_eq!(json_body, json!(["alt", "alt2"]));
 
             assert!(resp.status().is_success());
         }


### PR DESCRIPTION
- Add filter consistency to `users` and `bounds` APIs
- `users` has `limit` & `filter` param
- `bounds` has `limit` & `filter` param
- user list & bounds list no longer require 2 function with rocket@0.4

cc/ @ingalls
