### PR TITLE
Features should return application/json

### DIFF
--- a/src/schema.sql
+++ b/src/schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE deltas (
     finalized   BOOLEAN DEFAULT FALSE
 );
 CREATE INDEX deltas_idx ON deltas(id);
-CREATE INDEX deltas_affeted_idx on deltas USING GIN (affected);
+CREATE INDEX deltas_affected_idx on deltas USING GIN (affected);
 
 -- delete_geo( id, version )
 CREATE OR REPLACE FUNCTION delete_geo(BIGINT, BIGINT)


### PR DESCRIPTION
### Context

While debugging with @miccolis today I noticed the features API did not return the feature with the correct context type. This ensures features are returned with the content type set to `application/json`

cc/ @ingalls
