### PR TITLE
Limit geom by BBOX

### DIFF
--- a/src/mvt/mod.rs
+++ b/src/mvt/mod.rs
@@ -36,6 +36,8 @@ pub fn db_create(conn: &impl postgres::GenericConnection, z: &u8, x: &u32, y: &u
                 ST_AsMVTGeom(geom, ST_Transform(ST_MakeEnvelope($1, $2, $3, $4, $5), 4326), 4096, 256, false) AS geom
             FROM
                 geo
+            WHERE
+                ST_Intersects(geom, ST_Transform(ST_MakeEnvelope($1, $2, $3, $4, $5), 4326))
         ) q
     ", &[&bbox.minx, &bbox.miny, &bbox.maxx, &bbox.maxy, &grid.srid]) {
         Ok(res) => {


### PR DESCRIPTION
### Context

I misunderstood what `ST_AsMVTGeom` was expecting under the hood and assumed it would perform an RTree lookup on the provided geometry column.

In testing due to a limited database size, the tiles were being generated performantly.

This filters the geometry pool by adding an `ST_Intersects` clause with the bounding box

cc/ @ingalls
