### PR TITLE
Add bbox validation

### DIFF
--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -612,7 +612,7 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
 }
 
 pub fn get_point_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, point: &String) -> Result<PGStream, HecateError> {
-    let (lng, lat) = validate::point(point)?;
+    validate::point(point)?;
 
     Ok(PGStream::new(conn, String::from("next_features"), String::from(r#"
         DECLARE next_features CURSOR FOR
@@ -636,9 +636,7 @@ pub fn get_point_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConn
 }
 
 pub fn get_bbox_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, bbox: &Vec<f64>) -> Result<PGStream, HecateError> {
-    if bbox.len() != 4 {
-        return Err(HecateError::new(400, String::from("Invalid BBOX"), None));
-    }
+    validate::bbox(bbox)?;
 
     Ok(PGStream::new(conn, String::from("next_features"), String::from(r#"
         DECLARE next_features CURSOR FOR
@@ -661,9 +659,7 @@ pub fn get_bbox_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConne
 }
 
 pub fn get_bbox(conn: &impl postgres::GenericConnection, bbox: Vec<f64>) -> Result<geojson::FeatureCollection, HecateError> {
-    if bbox.len() != 4 {
-        return Err(HecateError::new(400, String::from("Invalid BBOX"), None));
-    }
+    let (lng, lat) = validate::bbox(bbox)?;
 
     match conn.query("
         SELECT

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -612,7 +612,7 @@ pub fn restore(trans: &postgres::transaction::Transaction, schema: &Option<valic
 }
 
 pub fn get_point_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>, point: &String) -> Result<PGStream, HecateError> {
-    validate::point(point)?;
+    let (lng, lat) = validate::point(point)?;
 
     Ok(PGStream::new(conn, String::from("next_features"), String::from(r#"
         DECLARE next_features CURSOR FOR
@@ -659,7 +659,7 @@ pub fn get_bbox_stream(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConne
 }
 
 pub fn get_bbox(conn: &impl postgres::GenericConnection, bbox: Vec<f64>) -> Result<geojson::FeatureCollection, HecateError> {
-    let (lng, lat) = validate::bbox(bbox)?;
+    validate::bbox(&bbox)?;
 
     match conn.query("
         SELECT

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -24,3 +24,26 @@ pub fn point(point: &String) -> Result<(f64, f64), HecateError> {
 
     Ok((lng, lat))
 }
+
+pub fn bbox(bbox: &Vec<f64>) -> Result<Vec<f64>, HecateError> {
+    if bbox.len() != 4 {
+        return Err(HecateError::new(400, String::from("Invalid BBOX"), None));
+    }
+
+    if bbox[0].is_nan() || bbox[0] < -180.0 || bbox[0] > 180.0 {
+        return Err(HecateError::new(400, String::from("BBOX minX value must be a number between -180 and 180", None));
+    } else if bbox[1].is_nan() || bbox[1] < -90.0 || bbox[1] > 90.0 {
+        return Err(HecateError::new(400, String::from("BBOX minY value must be a number between -90 and 90", None));
+    } else if bbox[2].is_nan() || bbox[2] < -180.0 || bbox[2] > 180.0 {
+        return Err(HecateError::new(400, String::from("BBOX maxX value must be a number between -180 and 180", None));
+    } else if bbox[3].is_nan() || bbox[3] < -90.0 || bbox[3] > 90.0 {
+        return Err(HecateError::new(400, String::from("BBOX maxY value must be a number between -90 and 90", None));
+    } else if bbox[0] > bbox[2] {
+        return Err(HecateError::new(400, String::from("BBOX minX value cannot be greater than maxX value", None));
+    } else if bbox[1] > bbox[3] {
+        return Err(HecateError::new(400, String::from("BBOX minY value cannot be greater than maxY value", None));
+    }
+
+    Ok(bbox)
+}
+

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -47,3 +47,43 @@ pub fn bbox(bbox: &Vec<f64>) -> Result<(), HecateError> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]   
+    fn valid_point() {
+        assert_eq!(point(&String::from("-34.696,70.56")).ok(),Some((-34.696,70.56)), "ok - point coordinates is valid.");
+    }
+
+    #[test]
+    fn invalid_point_longitude() {
+        match point(&String::from("lng,70.56")){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Longitude coordinate must be numeric",
+                "status": "Bad Request"
+            }), "not ok - the longitude is invalid."),
+        }
+    }
+
+    #[test]   
+    fn valid_bbox() {
+        assert_eq!(bbox(&[-107.578125,-30.600094,56.162109,46.377254].to_vec()).ok(),Some(()), "ok - point coordinates is valid.");
+    }
+
+    #[test]
+    fn invalid_bbox_minX() {
+        match bbox(&[-181.0,-30.600094,56.162109,46.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX minX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }), "not ok - the minX value is invalid."),
+        }
+    }
+}
+
+

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -31,19 +31,19 @@ pub fn bbox(bbox: &Vec<f64>) -> Result<Vec<f64>, HecateError> {
     }
 
     if bbox[0].is_nan() || bbox[0] < -180.0 || bbox[0] > 180.0 {
-        return Err(HecateError::new(400, String::from("BBOX minX value must be a number between -180 and 180", None));
+        return Err(HecateError::new(400, String::from("BBOX minX value must be a number between -180 and 180"), None));
     } else if bbox[1].is_nan() || bbox[1] < -90.0 || bbox[1] > 90.0 {
-        return Err(HecateError::new(400, String::from("BBOX minY value must be a number between -90 and 90", None));
+        return Err(HecateError::new(400, String::from("BBOX minY value must be a number between -90 and 90"), None));
     } else if bbox[2].is_nan() || bbox[2] < -180.0 || bbox[2] > 180.0 {
-        return Err(HecateError::new(400, String::from("BBOX maxX value must be a number between -180 and 180", None));
+        return Err(HecateError::new(400, String::from("BBOX maxX value must be a number between -180 and 180"), None));
     } else if bbox[3].is_nan() || bbox[3] < -90.0 || bbox[3] > 90.0 {
-        return Err(HecateError::new(400, String::from("BBOX maxY value must be a number between -90 and 90", None));
+        return Err(HecateError::new(400, String::from("BBOX maxY value must be a number between -90 and 90"), None));
     } else if bbox[0] > bbox[2] {
-        return Err(HecateError::new(400, String::from("BBOX minX value cannot be greater than maxX value", None));
+        return Err(HecateError::new(400, String::from("BBOX minX value cannot be greater than maxX value"), None));
     } else if bbox[1] > bbox[3] {
-        return Err(HecateError::new(400, String::from("BBOX minY value cannot be greater than maxY value", None));
+        return Err(HecateError::new(400, String::from("BBOX minY value cannot be greater than maxY value"), None));
     }
 
-    Ok(bbox)
+    Ok(bbox.to_vec())
 }
 

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -57,6 +57,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_point_incomplete() {
+        match point(&String::from("70.56")){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Point must be Lng,Lat",
+                "status": "Bad Request"
+            }), "not ok - the longitude is incomplete."),
+        }
+    }
+
+    #[test]
     fn invalid_point_longitude() {
         match point(&String::from("lng,70.56")){
             Ok(_) => (),
@@ -68,13 +80,61 @@ mod tests {
         }
     }
 
+    #[test]
+    fn invalid_point_latitude() {
+        match point(&String::from("-122.44578,none.986")){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Latitude coordinate must be numeric",
+                "status": "Bad Request"
+            }), "not ok - the latitude is invalid."),
+        }
+    }
+
+    #[test]
+    fn invalid_point_longitude_out() {
+        match point(&String::from("-181.578125,-30.600094")){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Longitude exceeds bounds",
+                "status": "Bad Request"
+            }), "not ok - the longitud is out of range."),
+        }
+    }
+
+    #[test]
+    fn invalid_point_latitude_out() {
+        match point(&String::from("-107.578125,-100.600094")){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Latitude exceeds bounds",
+                "status": "Bad Request"
+            }), "not ok - the latitude is out of range."),
+        }
+    }
+
     #[test]   
     fn valid_bbox() {
         assert_eq!(bbox(&[-107.578125,-30.600094,56.162109,46.377254].to_vec()).ok(),Some(()), "ok - point coordinates is valid.");
     }
 
     #[test]
-    fn invalid_bbox_minX() {
+    fn invalid_bbox_incomplete() {
+        match bbox(&[-181.0,-30.600094,56.162109].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "Invalid BBOX",
+                "status": "Bad Request"
+            }), "not ok - the BBOX is incomplete."),
+        }
+    }
+
+    #[test]
+    fn invalid_bbox_minx() {
         match bbox(&[-181.0,-30.600094,56.162109,46.377254].to_vec()){
             Ok(_) => (),
             Err(err) =>  assert_eq!(err.as_json(),json!({
@@ -84,6 +144,64 @@ mod tests {
             }), "not ok - the minX value is invalid."),
         }
     }
+
+    #[test]
+    fn invalid_bbox_miny() {
+        match bbox(&[-107.578125,-94.600094,56.162109,46.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX minY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }), "not ok - the minY value is invalid."),
+        }
+    }
+
+    #[test]
+    fn invalid_bbox_maxx() {
+        match bbox(&[-107.578125,-30.600094,190.162109,46.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX maxX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }), "not ok - the maxX value is invalid."),
+        }
+    }
+
+    #[test]
+    fn invalid_bbox_maxy() {
+        match bbox(&[-107.578125,-30.600094,56.162109,196.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX maxY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }), "not ok - the maxY value is invalid."),
+        }
+    }
+
+    #[test]
+    fn invalid_bbox_minx_gt_maxx() {
+        match bbox(&[107.578125,-30.600094,56.162109,46.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX minX value cannot be greater than maxX value",
+                "status": "Bad Request"
+            }), "not ok - the minX value is greater than maxX."),
+        }
+    }
+
+    #[test]
+    fn invalid_bbox_miny_gt_maxy() {
+        match bbox(&[-107.578125,30.600094,56.162109,-46.377254].to_vec()){
+            Ok(_) => (),
+            Err(err) =>  assert_eq!(err.as_json(),json!({
+                "code": 400,
+                "reason": "BBOX minY value cannot be greater than maxY value",
+                "status": "Bad Request"
+            }), "not ok - the minY value is greater than maxY."),
+        }
+    }
 }
-
-

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -25,7 +25,7 @@ pub fn point(point: &String) -> Result<(f64, f64), HecateError> {
     Ok((lng, lat))
 }
 
-pub fn bbox(bbox: &Vec<f64>) -> Result<Vec<f64>, HecateError> {
+pub fn bbox(bbox: &Vec<f64>) -> Result<(), HecateError> {
     if bbox.len() != 4 {
         return Err(HecateError::new(400, String::from("Invalid BBOX"), None));
     }
@@ -44,6 +44,6 @@ pub fn bbox(bbox: &Vec<f64>) -> Result<Vec<f64>, HecateError> {
         return Err(HecateError::new(400, String::from("BBOX minY value cannot be greater than maxY value"), None));
     }
 
-    Ok(bbox.to_vec())
+    Ok(())
 }
 

--- a/tests/feature_at.rs
+++ b/tests/feature_at.rs
@@ -196,6 +196,13 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        {
+            let resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,56.162109,46.377254").unwrap();
+            assert!(resp.status().is_success());
+            //TODO check body
+        }
+
+
         server.kill().unwrap();
     }
 }

--- a/tests/feature_at.rs
+++ b/tests/feature_at.rs
@@ -196,10 +196,76 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        {
-            let resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,56.162109,46.377254").unwrap();
-            assert!(resp.status().is_success());
-            //TODO check body
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-181.0,-30.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-100.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,190.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX maxX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,56.162109,100.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX maxY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=107.578125,-30.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minX value cannot be greater than maxX value",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,30.600094,56.162109,-46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minY value cannot be greater than maxY value",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
         }
 
 

--- a/tests/feature_at.rs
+++ b/tests/feature_at.rs
@@ -208,7 +208,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { // Check bbox - minX in bbox out of range
+        { // Check bbox - minY in bbox out of range
             let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-100.600094,56.162109,46.377254").unwrap();
             let json_body: serde_json::value::Value = resp.json().unwrap();
 
@@ -220,7 +220,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { // Check bbox - minX in bbox out of range
+        { // Check bbox - maxX in bbox out of range
             let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,190.162109,46.377254").unwrap();
             let json_body: serde_json::value::Value = resp.json().unwrap();
 
@@ -232,7 +232,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { // Check bbox - minX in bbox out of range
+        { // Check bbox - maxY in bbox out of range
             let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,-30.600094,56.162109,100.377254").unwrap();
             let json_body: serde_json::value::Value = resp.json().unwrap();
 
@@ -244,7 +244,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { // Check bbox - minX in bbox out of range
+        { // Check bbox - minX > maxX 
             let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=107.578125,-30.600094,56.162109,46.377254").unwrap();
             let json_body: serde_json::value::Value = resp.json().unwrap();
 
@@ -256,7 +256,7 @@ mod test {
             assert!(resp.status().is_client_error());
         }
 
-        { // Check bbox - minX in bbox out of range
+        { // Check bbox - minY > maxY
             let mut resp = reqwest::get("http://localhost:8000/api/data/features?bbox=-107.578125,30.600094,56.162109,-46.377254").unwrap();
             let json_body: serde_json::value::Value = resp.json().unwrap();
 


### PR DESCRIPTION
### Context
This PR fixes https://github.com/mapbox/Hecate/issues/66

There is no validation for bbox parameter.

###  Summary of changes
- [x] Move validation of array length to `validate/mod.rs`, and call the validate module(?) in `feature/mod.rs`
- [x] Added a `bbox` validation function to `validate/mod.rs`, and its unit test.
- [x] Added tests to integration tests for bbox validation

### Next steps
- [x] Review and merge


cc/ @ingalls @lizziegooding @miccolis 
