### PR TITLE
Add docs for alternative way to release versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,51 @@
 # Contributing
 
-## Merging Pull Requests
+## 1. Merging Pull Requests
 
-All PRs to master _must_ have a corresponding versioned release
+:warning: All PRs to master **_must_** have a corresponding versioned release
 
-- add CHANGELOG.md comment following current formatting
+- Add a `CHANGELOG.md` comment following current formatting, commit and push it.
+
+### Manual way
+
 - Bump the version in Cargo.toml
 - Bump the version in `src/lib.rs` (Top of file)
 - Bump the version in `src/cli.yml`
-- Build a linux release from a linux machine (`cargo build --release`)
+- Build a Linux release from a Linux machine (`cargo build --release`)
 - `git commit -am "v#.#.#`
 - `git tag v#.#.#`
 - `git push`
 - `git push --tags`
 - `cargo publish` (Optionally)
-- Via the github interface create a new release and upload the hecate binary
+
+### Automatic way
+
+- Run the `release script` without any argument to get the current version.
+
+```
+./release
+```
+
+- Run the `release script` and send the current version increased according to the change you are releasing.
+
+```
+./release 0.71.1
+```
+
+and you should get a comment like:
+```
+ok - 0.71.0 => 0.71.1
+ok - release pushed!
+```
+
+## 2. Create a new release
+
+Via the GitHub interface create a new release and upload the Hecate binary
+
+- Go to the [Hecate GitHub UI](https://github.com/mapbox/Hecate) and click in `releases`
+- Click on the version you just released, it will look like `v0.71.1`
+- In the publish release UI in Github
+    - Add as title the new released version. _i.e. `v0.71.1`_
+    - Copy your comment in the `CHANGELOG.md` and paste it in the description field.
+    - Upload the binary from you local machine `~/Hecate/target/release/hecate`
+    - Click on the `publish release button`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@
 ./release
 ```
 
-- Run the `release script` and send the current version increased according to the change you are releasing.
+- Run the release script with the first argument being the new version you intend to release
 
 ```
 ./release 0.71.1


### PR DESCRIPTION
### Context

We have a `./release` script that can be used to avoid manual releasing.

cc/ @ingalls
