### PR TITLE
Create/Delete/Update Webhooks with Read/Write db connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ fn meta_set(
 
 
 fn mvt_get(
-    conn: web::Data<DbReadWrite>,
+    conn: web::Data<DbReplica>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     path: web::Path<(u8, u32, u32)>
@@ -1144,7 +1144,7 @@ fn auth_get(
 }
 
 fn stats_get(
-    conn: web::Data<DbReadWrite>,
+    conn: web::Data<DbReplica>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>
 ) -> Result<Json<serde_json::Value>, HecateError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1010,7 +1010,7 @@ fn webhooks_get(
 }
 
 fn webhooks_delete(
-    conn: web::Data<DbReplica>,
+    conn: web::Data<DbReadWrite>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     id: web::Path<i64>
@@ -1021,7 +1021,7 @@ fn webhooks_delete(
 }
 
 fn webhooks_create(
-    conn: web::Data<DbReplica>,
+    conn: web::Data<DbReadWrite>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     webhook: Json<webhooks::WebHook>
@@ -1035,7 +1035,7 @@ fn webhooks_create(
 }
 
 fn webhooks_update(
-    conn: web::Data<DbReplica>,
+    conn: web::Data<DbReadWrite>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     mut webhook: Json<webhooks::WebHook>,


### PR DESCRIPTION
### Context

Previously, the `webhooks_create`, `webhooks_update`, and `webhooks_delete` functions used `DbReplica` connections to access Postgres, meaning that, if there were replicas, they could try to write to a read-only replica, resulting in `500` errors for the user. The postgres error we saw was `ERROR: cannot execute INSERT in a read-only transaction`. Note that requests to these endpoints would sometimes succeed if the connection happen to be routed to the main database rather than a replica. I also changed two connections for `get` endpoints that were using `DbReadWrite` connections to `DbReplica`.

## Next steps
- [ ] review
- [ ] release
- [ ] update downstream dependencies

cc/ @ingalls @miccolis @samely @mattciferri 
