### PR TITLE
DB Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hecate"
-version = "0.74.4"
+version = "0.75.0"
 dependencies = [
  "actix-files 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ fn meta_set(
 
 
 fn mvt_get(
-    conn: web::Data<DbReplica>,
+    conn: web::Data<DbReadWrite>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     path: web::Path<(u8, u32, u32)>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,8 @@ fn meta_set(
 
 
 fn mvt_get(
-    conn: web::Data<DbReadWrite>,
+    conn_write: web::Data<DbReadWrite>,
+    conn_read: web::Data<DbReplica>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     path: web::Path<(u8, u32, u32)>
@@ -418,7 +419,7 @@ fn mvt_get(
 
     if z > 17 { return Err(HecateError::new(404, String::from("Tile Not Found"), None)); }
 
-    let tile = mvt::get(&*conn.get()?, z, x, y, false)?;
+    let tile = mvt::get(&*conn_read.get()?, &*conn_write.get()?, z, x, y, false)?;
 
     Ok(HttpResponse::build(actix_web::http::StatusCode::OK)
         .content_type("application/x-protobuf")
@@ -455,7 +456,8 @@ fn mvt_wipe(
 }
 
 fn mvt_regen(
-    conn: web::Data<DbReadWrite>,
+    conn_write: web::Data<DbReadWrite>,
+    conn_read: web::Data<DbReplica>,
     mut auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>,
     path: web::Path<(u8, u32, u32)>
@@ -468,7 +470,7 @@ fn mvt_regen(
 
     if z > 17 { return Err(HecateError::new(404, String::from("Tile Not Found"), None)); }
 
-    let tile = mvt::get(&*conn.get()?, z, x, y, true)?;
+    let tile = mvt::get(&*conn_read.get()?, &*conn_write.get()?, z, x, y, true)?;
 
     Ok(HttpResponse::build(actix_web::http::StatusCode::OK)
         .content_type("application/x-protobuf")

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -78,7 +78,7 @@ fn worker(rx: crossbeam::Receiver<Task>, database: String) {
                 }
 
                 for tile in tiles {
-                    if mvt::get(&conn, tile.2, tile.0 as u32, tile.1 as u32, true).is_err() {
+                    if mvt::regen(&conn, tile.2, tile.0 as u32, tile.1 as u32).is_some() {
                         println!("Daemon: Failed to generate tile: {:?}", tile);
                     }
                 }


### PR DESCRIPTION
### Context

When using multiple database back-ends via the replica flag, the MVT Cache operation can throw an error due to the replica running the INSERT query instead of the master database.

cc/ @ingalls
