### PR TITLE
Filter out duplicates from get bounds call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hecate"
-version = "0.76.0"
+version = "0.77.1"
 dependencies = [
  "actix-files 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/release
+++ b/release
@@ -70,6 +70,9 @@ CHANGE_START=$(echo $(grep -n "## v${NVER}" CHANGELOG.md | grep -Eo '^[0-9]+') +
 CHANGE_END=$(echo $(grep -n "## v${CVER}" CHANGELOG.md | grep -Eo '^[0-9]+') - 1 | bc)
 CHANGE="$(sed -n "${CHANGE_START},${CHANGE_END}p" CHANGELOG.md)"
 
+# Ensure that a release can be built and Cargo.lock is updated
+cargo build --release
+
 git commit -am "v${NVER}"
 git tag "v${NVER}"
 

--- a/src/bounds/mod.rs
+++ b/src/bounds/mod.rs
@@ -99,6 +99,12 @@ pub fn get(conn: r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager
                     ) as b
                 WHERE
                     ST_Intersects(geo.geom, b.subgeom)
+                GROUP BY
+                    geo.id,
+                    geo.key,
+                    geo.version,
+                    geo.geom,
+                    geo.props
             ) t
     "#), &[&bounds]) {
         Ok(stream) => Ok(stream),


### PR DESCRIPTION
### Context

Currently, when performing a get bounds call on large area, it's possible to receive duplicated results, despite there being no duplicates in the source data. This is due to the possibility that a point can fall exactly on a subdivision line. This PR modifies the db call to filter out these duplicates.

### Summary of changes

- Adds a groupby to the get bounds db call.
- Adds `cargo build --release` to the release step, to ensure the lockfile gets updated for every release.

cc @ingalls @lizziegooding @samely @miccolis 
