### PR TITLE
History Retrieval Schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "hecate"
-version = "0.79.0-geo-history-3"
+version = "0.79.0-geo-history-4"
 dependencies = [
  "actix-files 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "hecate"
-version = "0.79.0"
+version = "0.79.0-geo-history-3"
 dependencies = [
  "actix-files 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hecate"
-version = "0.79.0-geo-history"
+version = "0.79.0-geo-history-1"
 edition = "2018"
 authors = ["ingalls <ingalls@protonmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hecate"
-version = "0.79.0"
+version = "0.79.0-geo-history"
 edition = "2018"
 authors = ["ingalls <ingalls@protonmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hecate"
-version = "0.79.0-geo-history-3"
+version = "0.79.0-geo-history-4"
 edition = "2018"
 authors = ["ingalls <ingalls@protonmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hecate"
-version = "0.79.0-geo-history-2"
+version = "0.79.0-geo-history-3"
 edition = "2018"
 authors = ["ingalls <ingalls@protonmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hecate"
-version = "0.79.0-geo-history-1"
+version = "0.79.0-geo-history-2"
 edition = "2018"
 authors = ["ingalls <ingalls@protonmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1455,7 +1455,7 @@ curl -X GET 'http://localhost:8000/api/data/features/?point=-95.2734375%2C36.031
 
 #### `GET` `/api/data/features/history`
 
-Return streaming Line-Delimited GeoJSON of all versions of features that fall within the provided BBOX or Point. This includes the current version of the feature.
+Return streaming Line-Delimited GeoJSON of all versions of features that fall within the provided BBOX or Point. This includes the current version of the feature. Features in `delete` state will not be included as their geometries are not recorded.
 
 Note: All streaming GeoJSON endpoints will send the Unicode End Of Transmission, EOT
 (`0x04`) on stream completion. This can be used to ensure that a stream did not exit early.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ curl https://sh.rustup.rs -sSf | sh
 
 - Hecate is designed to run on the latest stable version of Rust, but has been thoroughly tested with `1.38.0`. This will install `1.38.0`
 
-```bash 
+```bash
 curl https://sh.rustup.rs -sSf | sh -s --  --default-toolchain 1.38.0
 ```
 
@@ -1432,7 +1432,7 @@ curl -X GET 'http://localhost:8000/api/data/feature/1542/history'
 
 Return streaming Line-Delimited GeoJSON within the provided BBOX or Point
 
-Note: All streaming GeoJSON endpoints will send the Unitcode End Of Transmission, EOT
+Note: All streaming GeoJSON endpoints will send the Unicode End Of Transmission, EOT
 (`0x04`) on stream completion. This can be used to ensure that a stream did not exit early.
 
 
@@ -1451,6 +1451,31 @@ curl -X GET 'http://localhost:8000/api/data/features/?bbox=-122.51791%2C37.60447
 
 ```bash
 curl -X GET 'http://localhost:8000/api/data/features/?point=-95.2734375%2C36.03133177633187'
+```
+
+#### `GET` `/api/data/features/history`
+
+Return streaming Line-Delimited GeoJSON of all versions of features that fall within the provided BBOX or Point. This includes the current version of the feature.
+
+Note: All streaming GeoJSON endpoints will send the Unicode End Of Transmission, EOT
+(`0x04`) on stream completion. This can be used to ensure that a stream did not exit early.
+
+
+*Options*
+
+| Option | Notes |
+| :----: | ----- |
+| `bbox=<minX,minY,maxX,maxY>` | `Optional` Bounding Box in format `left,bottom,right,top` |
+| `point=<Lng,Lat>` | `Optional` Point to query for intersections |
+
+*Example*
+
+```bash
+curl -X GET 'http://localhost:8000/api/data/features/history?bbox=-122.51791%2C37.60447%2C-122.35499%2C37.83244'
+```
+
+```bash
+curl -X GET 'http://localhost:8000/api/data/features/history?point=-95.2734375%2C36.03133177633187'
 ```
 
 </details>

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,7 +1,7 @@
 name: Hecate
 author: Nicholas Ingalls <ingalls@protonmail.com>
 about: Data Storage Backend Focused on Speed and GeoJSON Interchange
-version: 0.79.0-geo-history-1
+version: 0.79.0-geo-history-2
 args:
     - database:
         short: d

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,7 +1,7 @@
 name: Hecate
 author: Nicholas Ingalls <ingalls@protonmail.com>
 about: Data Storage Backend Focused on Speed and GeoJSON Interchange
-version: 0.79.0-geo-history-3
+version: 0.79.0-geo-history-4
 args:
     - database:
         short: d

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,7 +1,7 @@
 name: Hecate
 author: Nicholas Ingalls <ingalls@protonmail.com>
 about: Data Storage Backend Focused on Speed and GeoJSON Interchange
-version: 0.79.0
+version: 0.79.0-geo-history
 args:
     - database:
         short: d

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,7 +1,7 @@
 name: Hecate
 author: Nicholas Ingalls <ingalls@protonmail.com>
 about: Data Storage Backend Focused on Speed and GeoJSON Interchange
-version: 0.79.0-geo-history-2
+version: 0.79.0-geo-history-3
 args:
     - database:
         short: d

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,7 +1,7 @@
 name: Hecate
 author: Nicholas Ingalls <ingalls@protonmail.com>
 about: Data Storage Backend Focused on Speed and GeoJSON Interchange
-version: 0.79.0-geo-history
+version: 0.79.0-geo-history-1
 args:
     - database:
         short: d

--- a/src/delta/mod.rs
+++ b/src/delta/mod.rs
@@ -38,32 +38,41 @@ impl Delta {
 }
 
 ///Get the history of a particular feature
+/// @TODO move to feature modules?
 pub fn history(conn: &impl postgres::GenericConnection, feat_id: &i64) -> Result<serde_json::Value, HecateError> {
     match conn.query("
-        SELECT json_agg(row_to_json(t))
-        FROM (
-            SELECT
-                deltas.id,
-                deltas.uid,
-                JSON_Array_Elements((deltas.features -> 'features')::JSON) AS feat,
-                users.username
-            FROM
-                deltas,
-                users
-            WHERE
-                affected @> ARRAY[$1]::BIGINT[]
-                AND users.id = deltas.uid
-            ORDER BY id DESC
-        ) t
-        WHERE
-            (feat->>'id')::BIGINT = $1;
+    SELECT json_agg (
+        JSON_Build_Object(
+            'id', deltas.id,
+            'uid', deltas.uid,
+            'feat', JSON_Build_Object(
+                'id', geo_history.id,
+                'action', geo_history.action,
+                'key', geo_history.key,
+                'type', 'Feature',
+                'version', geo_history.version,
+                'geometry', ST_AsGeoJSON(geom)::JSON,
+                'properties', geo_history.props
+            ),
+            'username', users.username
+        )
+        ORDER BY geo_history.version DESC
+    )
+    FROM
+        geo_history,
+        deltas,
+        users
+    WHERE
+        geo_history.id = $1 AND
+        geo_history.delta = deltas.id AND
+        deltas.uid = users.id
     ", &[&feat_id]) {
         Ok(res) => {
             if res.len() == 0 {
                 return Err(HecateError::new(400, String::from("Could not find history for given id"), None))
             }
-
             let history: serde_json::Value = res.get(0).get(0);
+
             Ok(history)
         },
         Err(err) => Err(HecateError::from_db(err))

--- a/src/delta/mod.rs
+++ b/src/delta/mod.rs
@@ -65,7 +65,7 @@ pub fn history(conn: &impl postgres::GenericConnection, feat_id: &i64) -> Result
     WHERE
         geo_history.id = $1 AND
         geo_history.delta = deltas.id AND
-        deltas.uid = users.id
+        deltas.uid = users.id;
     ", &[&feat_id]) {
         Ok(res) => {
             if res.len() == 0 {

--- a/src/delta/mod.rs
+++ b/src/delta/mod.rs
@@ -95,10 +95,8 @@ pub fn open(trans: &postgres::transaction::Transaction, props: &HashMap<String, 
 }
 
 pub fn create(trans: &postgres::transaction::Transaction, fc: &geojson::FeatureCollection, props: &HashMap<String, Option<String>>, uid: &i64) -> Result<i64, HecateError> {
-    let fc_str = serde_json::to_string(&fc).unwrap();
-
     match trans.query("
-        INSERT INTO deltas (id, created, features, uid, props, affected) VALUES (
+        INSERT INTO deltas (id, created, uid, props, affected) VALUES (
             nextval('deltas_id_seq'),
             current_timestamp,
             $1::TEXT::JSON,
@@ -106,7 +104,7 @@ pub fn create(trans: &postgres::transaction::Transaction, fc: &geojson::FeatureC
             to_json($3::HSTORE),
             $4
         ) RETURNING id;
-    ", &[&fc_str, &uid, &props, &affected(&fc)]) {
+    ", &[&uid, &props, &affected(&fc)]) {
         Err(err) => Err(HecateError::from_db(err)),
         Ok(res) => { Ok(res.get(0).get(0)) }
     }
@@ -206,11 +204,11 @@ pub fn list_by_offset(conn: &impl postgres::GenericConnection, offset: Option<i6
 pub fn tiles(conn: &impl postgres::GenericConnection, id: &i64, min_zoom: u8, max_zoom: u8) -> Result<Vec<(i32, i32, u8)>, HecateError> {
     match conn.query("
         SELECT
-            ST_GeomFromGeoJSON(json_array_elements((features->>'features')::JSON)->>'geometry')
+            geom
         FROM
-            deltas
+            geo_history
         WHERE
-            id = $1
+            delta = $1
     ", &[&id]) {
         Err(err) => Err(HecateError::from_db(err)),
         Ok(results) => {
@@ -257,24 +255,38 @@ pub fn tiles(conn: &impl postgres::GenericConnection, id: &i64, min_zoom: u8, ma
 
 pub fn get_json(conn: &impl postgres::GenericConnection, id: &i64) -> Result<serde_json::Value, HecateError> {
     match conn.query("
-        SELECT COALESCE(row_to_json(d), 'false'::JSON)
+        SELECT COALESCE(row_to_json(t), 'false'::JSON)
         FROM (
             SELECT
                 deltas.id,
                 deltas.uid,
                 users.username,
-                deltas.features,
+                (
+                    SELECT json_agg(row_to_json(d))
+                    FROM (
+                        SELECT
+                            id,
+                            action,
+                            key,
+                            'Feature' as type,
+                            version,
+                            ST_AsGeoJSON(geom)::JSON as geometry,
+                            props as properties
+                        FROM geo_history
+                        WHERE delta = $1
+                        ORDER BY id
+                    ) d
+                ) as features,
                 deltas.affected,
                 deltas.props,
-                deltas.created,
-                deltas.props
+                deltas.created
             FROM
                 deltas,
                 users
             WHERE
-                deltas.uid = users.id
-                AND deltas.id = $1
-        ) d
+                deltas.id = $1
+                AND deltas.uid = users.id
+        ) t
     ", &[&id]) {
         Err(err) => Err(HecateError::from_db(err)),
         Ok(res) => {
@@ -300,18 +312,15 @@ pub fn modify_props(id: &i64, trans: &postgres::transaction::Transaction, props:
 }
 
 pub fn modify(id: &i64, trans: &postgres::transaction::Transaction, fc: &geojson::FeatureCollection, uid: &i64) -> Result<i64, HecateError> {
-    let fc_str = serde_json::to_string(&fc).unwrap();
-
     match trans.query("
         UPDATE deltas
             SET
-                features = $2::TEXT::JSON,
-                affected = $4
+                affected = $3
             WHERE
                 id = $1
-                AND uid = $3
+                AND uid = $2
                 AND finalized = false;
-    ", &[&id, &fc_str, &uid, &affected(&fc)]) {
+    ", &[&id, &uid, &affected(&fc)]) {
         Err(err) => Err(HecateError::from_db(err)),
         _ => { Ok(*id) }
     }

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -823,3 +823,44 @@ pub fn get_bbox(conn: &impl postgres::GenericConnection, bbox: Vec<f64>) -> Resu
         Err(err) => Err(HecateError::from_db(err))
     }
 }
+
+///Get the history of a particular feature
+pub fn history(conn: &impl postgres::GenericConnection, feat_id: &i64) -> Result<serde_json::Value, HecateError> {
+    match conn.query("
+        SELECT json_agg (
+            JSON_Build_Object(
+                'id', deltas.id,
+                'uid', deltas.uid,
+                'feat', JSON_Build_Object(
+                    'id', geo_history.id,
+                    'action', geo_history.action,
+                    'key', geo_history.key,
+                    'type', 'Feature',
+                    'version', geo_history.version,
+                    'geometry', ST_AsGeoJSON(geom)::JSON,
+                    'properties', geo_history.props
+                ),
+                'username', users.username
+            )
+            ORDER BY geo_history.version DESC
+        )
+        FROM
+            geo_history,
+            deltas,
+            users
+        WHERE
+            geo_history.id = $1 AND
+            geo_history.delta = deltas.id AND
+            deltas.uid = users.id;
+    ", &[&feat_id]) {
+        Ok(res) => {
+            if res.len() == 0 {
+                return Err(HecateError::new(400, String::from("Could not find history for given id"), None))
+            }
+            let history: serde_json::Value = res.get(0).get(0);
+
+            Ok(history)
+        },
+        Err(err) => Err(HecateError::from_db(err))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1876,7 +1876,7 @@ fn feature_get_history(
     web::block(move || {
         auth_rules.0.allows_feature_history(&mut auth, auth::RW::Read)?;
 
-        Ok(delta::history(&*conn.get()?, &id.into_inner())?)
+        Ok(feature::history(&*conn.get()?, &id.into_inner())?)
     }).then(|res: Result<serde_json::Value, actix_threadpool::BlockingError<HecateError>>| match res {
         Ok(history) => Ok(actix_web::HttpResponse::Ok().json(history)),
         Err(err) => Ok(HecateError::from(err).error_response())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub static VERSION: &'static str = "0.79.0-geo-history";
+pub static VERSION: &'static str = "0.79.0-geo-history-1";
 pub static POSTGRES: f64 = 10.0;
 pub static POSTGIS: f64 = 2.4;
 pub static HOURS: i64 = 24;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub static VERSION: &'static str = "0.79.0-geo-history-1";
+pub static VERSION: &'static str = "0.79.0-geo-history-2";
 pub static POSTGRES: f64 = 10.0;
 pub static POSTGIS: f64 = 2.4;
 pub static HOURS: i64 = 24;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub static VERSION: &'static str = "0.79.0";
+pub static VERSION: &'static str = "0.79.0-geo-history";
 pub static POSTGRES: f64 = 10.0;
 pub static POSTGIS: f64 = 2.4;
 pub static HOURS: i64 = 24;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub static VERSION: &'static str = "0.79.0-geo-history-3";
+pub static VERSION: &'static str = "0.79.0-geo-history-4";
 pub static POSTGRES: f64 = 10.0;
 pub static POSTGIS: f64 = 2.4;
 pub static HOURS: i64 = 24;

--- a/src/migrations/README.md
+++ b/src/migrations/README.md
@@ -1,0 +1,6 @@
+<h1 align='center'>Migrations</h1>
+
+This directory contains database migrations. All migrations should be:
+- in `.sql` files
+- named `<table affected>-yyyy-mm-dd`, e.g. `geo_history-2019-11-24`
+- include a comment at the top describing what the migration does

--- a/src/migrations/README.md
+++ b/src/migrations/README.md
@@ -2,5 +2,5 @@
 
 This directory contains database migrations. All migrations should be:
 - in `.sql` files
-- named `<table affected>-yyyy-mm-dd`, e.g. `geo_history-2019-11-24`
+- named `<hecate version to be released>-<pre|post>`, e.g. `v0.80.0-post.sql`. Name migrations with `pre` if they're to be run before the new Hecate binary is to be deployed. Named migrations with `pro` if they're to be run after deploy.
 - include a comment at the top describing what the migration does

--- a/src/migrations/geo_history-2019-11-24.sql
+++ b/src/migrations/geo_history-2019-11-24.sql
@@ -1,0 +1,28 @@
+-- populates the geo_history table using the delta.features JSON
+
+INSERT INTO geo_history (id, delta, version, action, props, geom)
+SELECT
+    (feat->>'id')::BIGINT AS id,
+    id AS delta,
+    -- the version stored in the deltas.features blob is one behind
+    -- if it doesn't exist it should be 1, otherwise increment by 1
+    CASE
+        WHEN feat->>'version' IS NULL THEN 1
+        ELSE (feat->>'version')::BIGINT + 1
+    END AS version,
+    feat->>'action' AS action,
+    feat->'properties' AS props,
+    ST_SetSRID(
+        ST_MakePoint(
+            (feat->'geometry'->'coordinates'->>0)::FLOAT,
+            (feat->'geometry'->'coordinates'->>1)::FLOAT
+        ),
+        4326
+    ) AS geom
+FROM (
+    SELECT
+        id,
+        JSON_Array_Elements((features -> 'features')::JSON) AS feat
+    FROM
+        deltas
+) t;

--- a/src/migrations/geo_history-2019-11-24.sql
+++ b/src/migrations/geo_history-2019-11-24.sql
@@ -12,6 +12,7 @@ SELECT
     END AS version,
     feat->>'action' AS action,
     feat->'properties' AS props,
+    feat->>'key' AS key,
     ST_SetSRID(
         ST_MakePoint(
             (feat->'geometry'->'coordinates'->>0)::FLOAT,

--- a/src/migrations/v0.80.0-post.sql
+++ b/src/migrations/v0.80.0-post.sql
@@ -1,0 +1,3 @@
+-- removes the deltas.features column
+ALTER TABLE deltas
+DROP COLUMN IF EXISTS features;

--- a/src/migrations/v0.80.0-pre.sql
+++ b/src/migrations/v0.80.0-pre.sql
@@ -11,7 +11,7 @@ CREATE TABLE geo_history (
     PRIMARY KEY (id, version)
 );
 
-INSERT INTO geo_history (id, delta, version, action, props, geom)
+INSERT INTO geo_history (id, delta, version, action, props, key, geom)
 SELECT
     (feat->>'id')::BIGINT AS id,
     id AS delta,

--- a/src/migrations/v0.80.0-pre.sql
+++ b/src/migrations/v0.80.0-pre.sql
@@ -1,4 +1,15 @@
--- populates the geo_history table using the delta.features JSON
+-- creates, populates, and creates indexes on the geo_history table using the delta.features JSON
+DROP TABLE IF EXISTS geo_history;
+CREATE TABLE geo_history (
+    id          BIGINT NOT NULL,
+    delta       BIGINT NOT NULL,
+    key         TEXT,
+    action      TEXT NOT NULL,
+    version     BIGINT NOT NULL,
+    geom        GEOMETRY(GEOMETRY, 4326),
+    props       JSONB,
+    PRIMARY KEY (id, version)
+);
 
 INSERT INTO geo_history (id, delta, version, action, props, geom)
 SELECT
@@ -27,3 +38,7 @@ FROM (
     FROM
         deltas
 ) t;
+
+CREATE INDEX geo_history_gist ON geo_history USING GIST(geom);
+CREATE INDEX geo_history_idx ON geo_history(id);
+CREATE INDEX geo_history_deltax ON geo_history(delta);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -98,7 +98,6 @@ DROP TABLE IF EXISTS deltas;
 CREATE TABLE deltas (
     id          BIGSERIAL PRIMARY KEY,
     created     TIMESTAMP,
-    features    JSONB,
     affected    BIGINT[],
     props       JSONB,
     uid         BIGINT,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -72,7 +72,7 @@ CREATE INDEX deltas_idx ON deltas(id);
 CREATE INDEX deltas_affected_idx on deltas USING GIN (affected);
 
 CREATE TABLE geo (
-    id          BIGSERIAL UNIQUE,
+    id          BIGSERIAL PRIMARY KEY,
     key         TEXT UNIQUE,
     version     BIGINT NOT NULL,
     geom        GEOMETRY(GEOMETRY, 4326) NOT NULL,
@@ -83,12 +83,13 @@ CREATE INDEX geo_gist ON geo USING GIST(geom);
 CREATE INDEX geo_idx ON geo(id);
 
 CREATE TABLE geo_history (
-    id          BIGSERIAL UNIQUE,
+    id          BIGINT NOT NULL,
     delta       BIGINT NOT NULL REFERENCES deltas(id),
     key         TEXT UNIQUE,
     version     BIGINT NOT NULL,
     geom        GEOMETRY(GEOMETRY, 4326) NOT NULL,
-    props       JSONB NOT NULL
+    props       JSONB NOT NULL,
+    PRIMARY KEY (id, version)
 );
 CREATE INDEX geo_history_gist ON geo_history USING GIST(geom);
 CREATE INDEX geo_history_idx ON geo_history(id);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -76,8 +76,8 @@ CREATE TABLE geo_history (
     key         TEXT,
     action      TEXT NOT NULL,
     version     BIGINT NOT NULL,
-    geom        GEOMETRY(GEOMETRY, 4326) NOT NULL,
-    props       JSONB NOT NULL,
+    geom        GEOMETRY(GEOMETRY, 4326),
+    props       JSONB,
     PRIMARY KEY (id, version)
 );
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -87,11 +87,13 @@ CREATE TABLE geo_history (
     id          BIGINT NOT NULL,
     delta       BIGINT NOT NULL REFERENCES deltas(id),
     key         TEXT UNIQUE,
+    action      TEXT NOT NULL,
     version     BIGINT NOT NULL,
     geom        GEOMETRY(GEOMETRY, 4326) NOT NULL,
     props       JSONB NOT NULL,
     PRIMARY KEY (id, version)
 );
+
 CREATE INDEX geo_history_gist ON geo_history USING GIST(geom);
 CREATE INDEX geo_history_idx ON geo_history(id);
 CREATE INDEX geo_history_deltax ON geo_history(delta);

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE users_tokens (
 CREATE TABLE deltas (
     id          BIGSERIAL PRIMARY KEY,
     created     TIMESTAMP,
+    features    JSONB,
     affected    BIGINT[],
     props       JSONB,
     uid         BIGINT REFERENCES users(id),

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -73,7 +73,7 @@ DROP TABLE IF EXISTS geo_history;
 CREATE TABLE geo_history (
     id          BIGINT NOT NULL,
     delta       BIGINT NOT NULL,
-    key         TEXT UNIQUE,
+    key         TEXT,
     action      TEXT NOT NULL,
     version     BIGINT NOT NULL,
     geom        GEOMETRY(GEOMETRY, 4326) NOT NULL,

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -98,6 +98,22 @@ mod test {
             assert_eq!(resp.text().unwrap(), "true");
         }
 
+        { // Fetch delta 1
+            let mut resp = reqwest::get("http://localhost:8000/api/delta/1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body["affected"], json!([1, 2, 3]));
+            assert_eq!(json_body["id"], json!(1));
+            assert_eq!(json_body["props"], json!({ "message": "Basic Creation" }));
+            assert_eq!(json_body["uid"], json!(1));
+            assert_eq!(json_body["username"], json!("ingalls"));
+            assert_eq!(json_body["features"].to_string(), r#"[{"action":"create","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"shop":true},"type":"Feature","version":1},{"action":"create","geometry":{"coordinates":[1.1,1.1],"type":"Point"},"id":2,"key":null,"properties":{"shop":true},"type":"Feature","version":1},{"action":"create","geometry":{"coordinates":[1.2,1.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":1}]"#);
+            let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
+            assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
+            assert!(resp.status().is_success());
+        }
+
         { //Modify Points
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/features")
@@ -152,6 +168,22 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { // Fetch delta 2
+            let mut resp = reqwest::get("http://localhost:8000/api/delta/2").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body["affected"], json!([1, 2, 3]));
+            assert_eq!(json_body["id"], json!(2));
+            assert_eq!(json_body["props"], json!({ "message": "Basic Modify" }));
+            assert_eq!(json_body["uid"], json!(1));
+            assert_eq!(json_body["username"], json!("ingalls"));
+            assert_eq!(json_body["features"].to_string(), r#"[{"action":"modify","geometry":{"coordinates":[2,2],"type":"Point"},"id":1,"key":null,"properties":{"shop":false},"type":"Feature","version":2},{"action":"modify","geometry":{"coordinates":[0.1,0.1],"type":"Point"},"id":2,"key":null,"properties":{"building":true,"shop":true},"type":"Feature","version":2},{"action":"modify","geometry":{"coordinates":[2.2,2.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":2}]"#);
+            let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
+            assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
+            assert!(resp.status().is_success());
+        }
+
         { //Create More Points
             let client = reqwest::Client::new();
             let mut resp = client.post("http://localhost:8000/api/data/features")
@@ -200,34 +232,6 @@ mod test {
         }
 
         {
-            let mut resp = reqwest::get("http://localhost:8000/api/delta/1").unwrap();
-
-            let json_body: serde_json::value::Value = resp.json().unwrap();
-
-            assert_eq!(json_body["affected"], json!([1, 2, 3]));
-            assert_eq!(json_body["id"], json!(1));
-            assert_eq!(json_body["props"], json!({ "message": "Basic Creation" }));
-            assert_eq!(json_body["uid"], json!(1));
-            assert_eq!(json_body["username"], json!("ingalls"));
-
-            assert!(resp.status().is_success());
-        }
-
-        {
-            let mut resp = reqwest::get("http://localhost:8000/api/delta/2").unwrap();
-
-            let json_body: serde_json::value::Value = resp.json().unwrap();
-
-            assert_eq!(json_body["affected"], json!([1, 2, 3]));
-            assert_eq!(json_body["id"], json!(2));
-            assert_eq!(json_body["props"], json!({ "message": "Basic Modify" }));
-            assert_eq!(json_body["uid"], json!(1));
-            assert_eq!(json_body["username"], json!("ingalls"));
-
-            assert!(resp.status().is_success());
-        }
-
-        {
             let mut resp = reqwest::get("http://localhost:8000/api/deltas").unwrap();
 
             let json_body: serde_json::value::Value = resp.json().unwrap();
@@ -253,7 +257,7 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        {
+        { //Test offset param
             let mut resp = reqwest::get("http://localhost:8000/api/deltas?offset=2").unwrap();
 
             let json_body: serde_json::value::Value = resp.json().unwrap();
@@ -264,7 +268,7 @@ mod test {
             assert!(resp.status().is_success());
         }
 
-        {
+        { //Test limit and offset param
             let mut resp = reqwest::get("http://localhost:8000/api/deltas?offset=2&limit=1").unwrap();
 
             let json_body: serde_json::value::Value = resp.json().unwrap();

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -108,11 +108,14 @@ mod test {
             assert_eq!(json_body["props"], json!({ "message": "Basic Creation" }));
             assert_eq!(json_body["uid"], json!(1));
             assert_eq!(json_body["username"], json!("ingalls"));
-            assert_eq!(json_body["features"], json!([
-                {"action":"create","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
-                {"action":"create","geometry":{"coordinates":[1.1,1.1],"type":"Point"},"id":2,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
-                {"action":"create","geometry":{"coordinates":[1.2,1.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":1}
-            ]));
+            assert_eq!(json_body["features"], json!({
+                "type": "FeatureCollection",
+                "features": [
+                    {"action":"create","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
+                    {"action":"create","geometry":{"coordinates":[1.1,1.1],"type":"Point"},"id":2,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
+                    {"action":"create","geometry":{"coordinates":[1.2,1.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":1}
+                ]
+            }));
             let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
             assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
             assert!(resp.status().is_success());
@@ -182,11 +185,14 @@ mod test {
             assert_eq!(json_body["props"], json!({ "message": "Basic Modify" }));
             assert_eq!(json_body["uid"], json!(1));
             assert_eq!(json_body["username"], json!("ingalls"));
-            assert_eq!(json_body["features"], json!([
-                {"action":"modify","geometry":{"coordinates":[2,2],"type":"Point"},"id":1,"key":null,"properties":{"shop":false},"type":"Feature","version":2},
-                {"action":"modify","geometry":{"coordinates":[0.1,0.1],"type":"Point"},"id":2,"key":null,"properties":{"building":true,"shop":true},"type":"Feature","version":2},
-                {"action":"modify","geometry":{"coordinates":[2.2,2.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":2}
-            ]));
+            assert_eq!(json_body["features"], json!({
+                "type": "FeatureCollection",
+                "features": [
+                    {"action":"modify","geometry":{"coordinates":[2,2],"type":"Point"},"id":1,"key":null,"properties":{"shop":false},"type":"Feature","version":2},
+                    {"action":"modify","geometry":{"coordinates":[0.1,0.1],"type":"Point"},"id":2,"key":null,"properties":{"building":true,"shop":true},"type":"Feature","version":2},
+                    {"action":"modify","geometry":{"coordinates":[2.2,2.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":2}
+                ]
+            }));
             let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
             assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
             assert!(resp.status().is_success());

--- a/tests/deltas.rs
+++ b/tests/deltas.rs
@@ -108,7 +108,11 @@ mod test {
             assert_eq!(json_body["props"], json!({ "message": "Basic Creation" }));
             assert_eq!(json_body["uid"], json!(1));
             assert_eq!(json_body["username"], json!("ingalls"));
-            assert_eq!(json_body["features"].to_string(), r#"[{"action":"create","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"shop":true},"type":"Feature","version":1},{"action":"create","geometry":{"coordinates":[1.1,1.1],"type":"Point"},"id":2,"key":null,"properties":{"shop":true},"type":"Feature","version":1},{"action":"create","geometry":{"coordinates":[1.2,1.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":1}]"#);
+            assert_eq!(json_body["features"], json!([
+                {"action":"create","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
+                {"action":"create","geometry":{"coordinates":[1.1,1.1],"type":"Point"},"id":2,"key":null,"properties":{"shop":true},"type":"Feature","version":1},
+                {"action":"create","geometry":{"coordinates":[1.2,1.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":1}
+            ]));
             let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
             assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
             assert!(resp.status().is_success());
@@ -178,7 +182,11 @@ mod test {
             assert_eq!(json_body["props"], json!({ "message": "Basic Modify" }));
             assert_eq!(json_body["uid"], json!(1));
             assert_eq!(json_body["username"], json!("ingalls"));
-            assert_eq!(json_body["features"].to_string(), r#"[{"action":"modify","geometry":{"coordinates":[2,2],"type":"Point"},"id":1,"key":null,"properties":{"shop":false},"type":"Feature","version":2},{"action":"modify","geometry":{"coordinates":[0.1,0.1],"type":"Point"},"id":2,"key":null,"properties":{"building":true,"shop":true},"type":"Feature","version":2},{"action":"modify","geometry":{"coordinates":[2.2,2.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":2}]"#);
+            assert_eq!(json_body["features"], json!([
+                {"action":"modify","geometry":{"coordinates":[2,2],"type":"Point"},"id":1,"key":null,"properties":{"shop":false},"type":"Feature","version":2},
+                {"action":"modify","geometry":{"coordinates":[0.1,0.1],"type":"Point"},"id":2,"key":null,"properties":{"building":true,"shop":true},"type":"Feature","version":2},
+                {"action":"modify","geometry":{"coordinates":[2.2,2.2],"type":"Point"},"id":3,"key":null,"properties":{"shop":true},"type":"Feature","version":2}
+            ]));
             let keys: Vec<String> = json_body.as_object().unwrap().keys().map(|k| k.to_owned()).collect();
             assert_eq!(keys, vec![String::from("affected"), String::from("created"), String::from("features"), String::from("id"), String::from("props"), String::from("uid"), String::from("username")]);
             assert!(resp.status().is_success());

--- a/tests/feature_history_at.rs
+++ b/tests/feature_history_at.rs
@@ -184,13 +184,36 @@ mod test {
 
         { //Check Point - success
             let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=0.0%2C0.0").unwrap();
+            assert!(resp.status().is_success());
 
             let mut body_str = String::from(resp.text().unwrap());
             body_str.pop();
             body_str.pop();
+            let features: Vec<&str> = body_str.split("\n").collect();
 
-            assert_eq!(&*body_str, "{\"id\":1,\"action\":\"create\",\"key\":null,\"delta\":1,\"type\":\"Feature\",\"version\":1,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"number\": \"123\"}}\n{\"id\":1,\"action\":\"modify\",\"key\":null,\"delta\":2,\"type\":\"Feature\",\"version\":2,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"test\": true, \"number\": \"123\"}}");
-            assert!(resp.status().is_success());
+            let feat1: serde_json::value::Value = serde_json::from_str(features[0]).unwrap();
+            assert_eq!(feat1, json!({
+                "type": "Feature",
+                "delta": 1,
+                "id": 1,
+                "key": null,
+                "version": 1,
+                "action": "create",
+                "properties": { "number": "123" },
+                "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+            }));
+
+            let feat2: serde_json::value::Value = serde_json::from_str(features[1]).unwrap();
+            assert_eq!(feat2, json!({
+                "type": "Feature",
+                "delta": 2,
+                "id": 1,
+                "key": null,
+                "version": 2,
+                "action": "modify",
+                "properties": { "number": "123", "test": true },
+                "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+            }));
         }
 
         { // Check bbox - minX in bbox out of range
@@ -267,13 +290,36 @@ mod test {
 
         { //Check BBOX - success
             let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-1,-1,1,1").unwrap();
+            assert!(resp.status().is_success());
 
             let mut body_str = String::from(resp.text().unwrap());
             body_str.pop();
             body_str.pop();
+            let features: Vec<&str> = body_str.split("\n").collect();
 
-            assert_eq!(&*body_str, "{\"id\":1,\"action\":\"create\",\"key\":null,\"delta\":1,\"type\":\"Feature\",\"version\":1,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"number\": \"123\"}}\n{\"id\":1,\"action\":\"modify\",\"key\":null,\"delta\":2,\"type\":\"Feature\",\"version\":2,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"test\": true, \"number\": \"123\"}}");
-            assert!(resp.status().is_success());
+            let feat1: serde_json::value::Value = serde_json::from_str(features[0]).unwrap();
+            assert_eq!(feat1, json!({
+                "type": "Feature",
+                "delta": 1,
+                "id": 1,
+                "key": null,
+                "version": 1,
+                "action": "create",
+                "properties": { "number": "123" },
+                "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+            }));
+
+            let feat2: serde_json::value::Value = serde_json::from_str(features[1]).unwrap();
+            assert_eq!(feat2, json!({
+                "type": "Feature",
+                "delta": 2,
+                "id": 1,
+                "key": null,
+                "version": 2,
+                "action": "modify",
+                "properties": { "number": "123", "test": true },
+                "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+            }));
         }
 
         server.kill().unwrap();

--- a/tests/feature_history_at.rs
+++ b/tests/feature_history_at.rs
@@ -1,0 +1,281 @@
+extern crate reqwest;
+extern crate postgres;
+#[macro_use] extern crate serde_json;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+    use serde_json;
+
+    #[test]
+    fn feature_history_at() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").args(&[ "run" ]).spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+
+        { //Create Username
+            let mut resp = reqwest::get("http://localhost:8000/api/user/create?username=ingalls&password=yeahehyeah&email=ingalls@protonmail.com").unwrap();
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        { //Create Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "type": "Feature",
+                    "action": "create",
+                    "message": "Creating a Point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+            assert_eq!(resp.text().unwrap(), "true");
+        }
+
+        { //Modify Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 1,
+                    "action": "modify",
+                    "message": "Modify a Point",
+                    "properties": { "number": "123", "test": true },
+                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert!(resp.status().is_success());
+            assert_eq!(resp.text().unwrap(), "true");
+        }
+
+        { //Invalid Point Lng,Lat
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Point must be Lng,Lat",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - non numeric lng
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=hey%2C1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Longitude coordinate must be numeric",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - non numeric lat
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=1%2Chey").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Latitude coordinate must be numeric",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - Lng out of bounds neg
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=-190%2C1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Longitude exceeds bounds",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - Lng out of bounds pos
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=190%2C1").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Longitude exceeds bounds",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - Lat out of bounds neg
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=1%2C-100").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Latitude exceeds bounds",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Invalid Point Lng,Lat - Lat out of bounds pos
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=1%2C100").unwrap();
+
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "Latitude exceeds bounds",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Check Point - success
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?point=0.0%2C0.0").unwrap();
+
+            let mut body_str = String::from(resp.text().unwrap());
+            body_str.pop();
+            body_str.pop();
+
+            assert_eq!(&*body_str, "{\"id\":1,\"action\":\"create\",\"key\":null,\"delta\":1,\"type\":\"Feature\",\"version\":1,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"number\": \"123\"}}\n{\"id\":1,\"action\":\"modify\",\"key\":null,\"delta\":2,\"type\":\"Feature\",\"version\":2,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"test\": true, \"number\": \"123\"}}");
+            assert!(resp.status().is_success());
+        }
+
+        { // Check bbox - minX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-181.0,-30.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minY in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-107.578125,-100.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - maxX in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-107.578125,-30.600094,190.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX maxX value must be a number between -180 and 180",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - maxY in bbox out of range
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-107.578125,-30.600094,56.162109,100.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX maxY value must be a number between -90 and 90",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minX > maxX
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=107.578125,-30.600094,56.162109,46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minX value cannot be greater than maxX value",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { // Check bbox - minY > maxY
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-107.578125,30.600094,56.162109,-46.377254").unwrap();
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+
+            assert_eq!(json_body, json!({
+                "code": 400,
+                "reason": "BBOX minY value cannot be greater than maxY value",
+                "status": "Bad Request"
+            }));
+            assert!(resp.status().is_client_error());
+        }
+
+        { //Check BBOX - success
+            let mut resp = reqwest::get("http://localhost:8000/api/data/features/history?bbox=-1,-1,1,1").unwrap();
+
+            let mut body_str = String::from(resp.text().unwrap());
+            body_str.pop();
+            body_str.pop();
+
+            assert_eq!(&*body_str, "{\"id\":1,\"action\":\"create\",\"key\":null,\"delta\":1,\"type\":\"Feature\",\"version\":1,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"number\": \"123\"}}\n{\"id\":1,\"action\":\"modify\",\"key\":null,\"delta\":2,\"type\":\"Feature\",\"version\":2,\"geometry\":{\"type\":\"Point\",\"coordinates\":[0,0]},\"properties\":{\"test\": true, \"number\": \"123\"}}");
+            assert!(resp.status().is_success());
+        }
+
+        server.kill().unwrap();
+    }
+}

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -1,5 +1,6 @@
 extern crate reqwest;
 extern crate postgres;
+#[macro_use] extern crate serde_json;
 
 #[cfg(test)]
 mod test {
@@ -10,6 +11,7 @@ mod test {
     use std::time::Duration;
     use std::thread;
     use reqwest;
+    use serde_json;
 
     #[test]
     fn history() {
@@ -70,7 +72,10 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!([
+                {"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}
+            ]));
             assert!(resp.status().is_success());
         }
 
@@ -97,7 +102,11 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!([
+                {"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}
+            ]));
             assert!(resp.status().is_success());
         }
 
@@ -124,7 +133,12 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!([
+                {"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}
+            ]));
             assert!(resp.status().is_success());
         }
 
@@ -151,7 +165,13 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(),r#"[{"feat":{"action":"restore","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":4},"id":4,"uid":1,"username":"ingalls"},{"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
+            let json_body: serde_json::value::Value = resp.json().unwrap();
+            assert_eq!(json_body, json!([
+                {"feat":{"action":"restore","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":4},"id":4,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},
+                {"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}
+            ]));
             assert!(resp.status().is_success());
         }
 

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -70,7 +70,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"create","geometry":{"coordinates":[0.0,0.0],"type":"Point"},"id":1,"message":"Creating a Point","properties":{"number":"123"},"type":"Feature"},"id":1,"uid":1,"username":"ingalls"}]"#);
+            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
             assert!(resp.status().is_success());
         }
 

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -128,6 +128,33 @@ mod test {
             assert!(resp.status().is_success());
         }
 
+        { //Restore Point
+            let client = reqwest::Client::new();
+            let mut resp = client.post("http://localhost:8000/api/data/feature")
+                .body(r#"{
+                    "id": 1,
+                    "type": "Feature",
+                    "version": 3,
+                    "action": "restore",
+                    "message": "Restore previously deleted point",
+                    "properties": { "number": "123" },
+                    "geometry": { "type": "Point", "coordinates": [ 1, 1 ] }
+                }"#)
+                .basic_auth("ingalls", Some("yeahehyeah"))
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .send()
+                .unwrap();
+
+            assert_eq!(resp.text().unwrap(), "true");
+            assert!(resp.status().is_success());
+        }
+
+        {
+            let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
+            assert_eq!(resp.text().unwrap(),r#"[{"feat":{"action":"restore","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":4},"id":4,"uid":1,"username":"ingalls"},{"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
+            assert!(resp.status().is_success());
+        }
+
         server.kill().unwrap();
     }
 }

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -97,7 +97,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"modify","geometry":{"coordinates":[1.0,1.0],"type":"Point"},"id":1,"message":"Modify a Point","properties":{"number":"123","test":true},"type":"Feature","version":1},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0.0,0.0],"type":"Point"},"id":1,"message":"Creating a Point","properties":{"number":"123"},"type":"Feature"},"id":1,"uid":1,"username":"ingalls"}]"#);
+            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
             assert!(resp.status().is_success());
         }
 

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -124,7 +124,7 @@ mod test {
 
         {
             let mut resp = reqwest::get("http://localhost:8000/api/data/feature/1/history").unwrap();
-            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"delete","geometry":null,"id":1,"message":"Delete a Point","properties":{},"type":"Feature","version":2},"id":3,"uid":1,"username":"ingalls"},{"feat":{"action":"modify","geometry":{"coordinates":[1.0,1.0],"type":"Point"},"id":1,"message":"Modify a Point","properties":{"number":"123","test":true},"type":"Feature","version":1},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0.0,0.0],"type":"Point"},"id":1,"message":"Creating a Point","properties":{"number":"123"},"type":"Feature"},"id":1,"uid":1,"username":"ingalls"}]"#);
+            assert_eq!(resp.text().unwrap(), r#"[{"feat":{"action":"delete","geometry":null,"id":1,"key":null,"properties":null,"type":"Feature","version":3},"id":3,"uid":1,"username":"ingalls"},{"feat":{"action":"modify","geometry":{"coordinates":[1,1],"type":"Point"},"id":1,"key":null,"properties":{"number":"123","test":true},"type":"Feature","version":2},"id":2,"uid":1,"username":"ingalls"},{"feat":{"action":"create","geometry":{"coordinates":[0,0],"type":"Point"},"id":1,"key":null,"properties":{"number":"123"},"type":"Feature","version":1},"id":1,"uid":1,"username":"ingalls"}]"#);
             assert!(resp.status().is_success());
         }
 


### PR DESCRIPTION
### Context

We currently support full feature history retrieval that is based on the stored FeatureCollection within a given delta.

Although this allows us to return a full geometry for any given feature in time, it is very slow due to having to iterate through all the features in a given delta to find the requested feature.

This PR scopes breaking out the features in a given delta to be contained in their own table.

The new feature history query would then be able to simply select the feature history out of a single table with no additional parsing

### Feature History

```SQL
SELECT
  *
FROM
  geo_history
WHERE
  id = 123
ORDER BY
  VERSION DESC
```

### Delta Retrieval

```SQL
SELECT
  deltas.id,
  deltas.uid,
  users.username,
  geo_history.id,
  deltas.affected,
  deltas.props,
  deltas.created,
  deltas.props
 FROM
  deltas
  INNER JOIN users
    ON deltas.uid = users.id,
  geo_history
WHERE
  deltas.id = geo_history.delta
```

cc/ @ingalls
