### PR TITLE
Simplify Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,6 @@ have a map containing the auth for each subkey.
 | ------------------------------------- | ------------------------- | :-----------: | ------------------------- | :---: |
 | `GET /api`                            | `server`                  | `public`      | All                       |       |
 | **Server Meta**                       | `meta`                    |               | `null`                    | 2     |
-| `GET /api/meta`                       | `meta::list`              | `public`      | All                       |       |
 | `GET /api/meta/<key>`                 | `meta::get`               | `public`      | All                       |       |
 | `POST /api/meta/<key>`                | `meta::set`               | `admin`       | `user`, `admin`, `null`   |       |
 | **JSON Schema**                       | `schema`                  |               | `null`                    | 2     |
@@ -540,13 +539,10 @@ have a map containing the auth for each subkey.
 | `GET /api/delta/<id>`                 | `delta::get`              | `public`      | All                       |       |
 | `GET /api/deltas`                     | `delta::list`             | `public`      | All                       |       |
 | **Webhooks**                          | `webhooks`                |               | `null`                    | 2     |
-| `GET /api/webhooks`                   | `webhooks::list`          | `admin`       | All                       |       |
-| `GET /api/webhooks/<id>`              | `webhooks::list`          | `admin`       | All                       |       |
-| `GET /api/webhooks/<id>`              | `webhooks::delete`        | `admin`       | All                       |       |
-| `POST /api/webhooks/<id>`             | `webhooks::update`        | `admin`       | All                       |       |
+| `GET /api/webhooks/<id>`              | `webhooks::get`           | `admin`       | All                       |       |
+| `POST /api/webhooks/<id>`             | `webhooks::set`           | `admin`       | All                       |       |
 | **Data Stats**                        | `stats`                   | `public`      | All                       |       |
 | `GET /api/data/stats`                 | `stats::get`              | `public`      | All                       |       |
-| `GET /api/data/bounds/<id>/stats`     | `stats::bounds`           | `public`      | All                       |       |
 | **Features**                          | `feature`                 |               | `null`                    | 2     |
 | `POST /api/data/feature(s)`           | `feature::create`         | `user`        | `user`, `admin`, `null`   |       |
 | `GET /api/data/feature/<id>`          | `feature::get`            | `public`      | All                       |       |

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -430,13 +430,13 @@ impl AuthModule for AuthStyle {
             },
             None => {
                 Ok(Box::new(AuthStyle {
-                    create: String::from("self"),
-                    patch: String::from("self"),
-                    set_public: String::from("self"),
-                    set_private: String::from("self"),
-                    delete: String::from("self"),
-                    get: String::from("public"),
-                    list: String::from("public")
+                    create: String::from("disabled"),
+                    patch: String::from("disabled"),
+                    set_public: String::from("disabled"),
+                    set_private: String::from("disabled"),
+                    delete: String::from("disabled"),
+                    get: String::from("disabled"),
+                    list: String::from("disabled")
                 }))
             }
         }

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -123,23 +123,23 @@ impl ValidAuth for AuthMeta {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthClone {
-    pub get: Option<String>,
-    pub query: Option<String>
+    pub get: String,
+    pub query: String
 }
 
 impl AuthClone {
     fn new() -> Self {
         AuthClone {
-            get: Some(String::from("user")),
-            query: Some(String::from("user"))
+            get: String::from("user"),
+            query: String::from("user")
         }
     }
 }
 
 impl ValidAuth for AuthClone {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("clone::get", &self.get)?;
-        is_all("clone::query", &self.query)?;
+        is_all("clone::get", &Some(self.get.clone()))?;
+        is_all("clone::query", &Some(self.query.clone()))?;
 
         Ok(true)
     }
@@ -147,20 +147,20 @@ impl ValidAuth for AuthClone {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthSchema {
-    pub get: Option<String>
+    pub get: String
 }
 
 impl AuthSchema {
     fn new() -> Self {
         AuthSchema {
-            get: Some(String::from("public"))
+            get: String::from("public")
         }
     }
 }
 
 impl ValidAuth for AuthSchema {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("schema::get", &self.get)?;
+        is_all("schema::get", &Some(self.get.clone()))?;
 
         Ok(true)
     }
@@ -168,23 +168,20 @@ impl ValidAuth for AuthSchema {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthStats {
-    pub get: Option<String>,
-    pub bounds: Option<String>
+    pub get: String
 }
 
 impl AuthStats {
     fn new() -> Self {
         AuthStats {
-            get: Some(String::from("public")),
-            bounds: Some(String::from("public"))
+            get: String::from("public"),
         }
     }
 }
 
 impl ValidAuth for AuthStats {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("stats::get", &self.get)?;
-        is_all("stats::bounds", &self.bounds)?;
+        is_all("stats::get", &Some(self.get.clone()))?;
 
         Ok(true)
     }
@@ -192,20 +189,20 @@ impl ValidAuth for AuthStats {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthAuth {
-    pub get: Option<String>
+    pub get: String
 }
 
 impl AuthAuth {
     fn new() -> Self {
         AuthAuth {
-            get: Some(String::from("public"))
+            get: String::from("public")
         }
     }
 }
 
 impl ValidAuth for AuthAuth {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("auth::get", &self.get)?;
+        is_all("auth::get", &Some(self.get.clone()))?;
 
         Ok(true)
     }
@@ -213,29 +210,29 @@ impl ValidAuth for AuthAuth {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthMVT {
-    pub get: Option<String>,
-    pub delete: Option<String>,
-    pub regen: Option<String>,
-    pub meta: Option<String>
+    pub get: String,
+    pub delete: String,
+    pub regen: String,
+    pub meta: String
 }
 
 impl AuthMVT {
     fn new() -> Self {
         AuthMVT {
-            get: Some(String::from("public")),
-            delete: Some(String::from("admin")),
-            regen: Some(String::from("user")),
-            meta: Some(String::from("public"))
+            get: String::from("public"),
+            delete: String::from("admin"),
+            regen: String::from("user"),
+            meta: String::from("public")
         }
     }
 }
 
 impl ValidAuth for AuthMVT {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("mvt::get", &self.get)?;
-        is_all("mvt::regen", &self.regen)?;
-        is_all("mvt::delete", &self.regen)?;
-        is_all("mvt::meta", &self.meta)?;
+        is_all("mvt::get", &Some(self.get.clone()))?;
+        is_all("mvt::regen", &Some(self.regen.clone()))?;
+        is_all("mvt::delete", &Some(self.regen.clone()))?;
+        is_all("mvt::meta", &Some(self.meta.clone()))?;
 
         Ok(true)
     }
@@ -425,16 +422,16 @@ pub struct CustomAuth {
     pub server: String,
     pub meta: AuthMeta,
     pub webhooks: AuthWebhooks,
-    pub stats: Option<AuthStats>,
-    pub mvt: Option<AuthMVT>,
-    pub schema: Option<AuthSchema>,
-    pub auth: Option<AuthAuth>,
+    pub stats: AuthStats,
+    pub mvt: AuthMVT,
+    pub schema: AuthSchema,
+    pub auth: AuthAuth,
     pub user: Option<AuthUser>,
     pub feature: Option<AuthFeature>,
     pub style: Option<AuthStyle>,
     pub delta: Option<AuthDelta>,
     pub bounds: Option<AuthBounds>,
-    pub clone: Option<AuthClone>,
+    pub clone: AuthClone,
     pub osm: Option<AuthOSM>
 }
 
@@ -443,16 +440,10 @@ impl ValidAuth for CustomAuth {
         is_all("server", &Some(self.server.clone()))?;
 
         &self.meta.is_valid()?;
-
-        match &self.mvt {
-            None => (),
-            Some(ref mvt) => { mvt.is_valid()?; }
-        };
-
-        match &self.schema {
-            None => (),
-            Some(ref schema) => { schema.is_valid()?; }
-        };
+        &self.mvt.is_valid()?;
+        &self.stats.is_valid()?;
+        &self.clone.is_valid()?;
+        &self.schema.is_valid()?;
 
         match &self.user {
             None => (),
@@ -477,11 +468,6 @@ impl ValidAuth for CustomAuth {
         match &self.bounds {
             None => (),
             Some(ref bounds) => { bounds.is_valid()?; }
-        };
-
-        match &self.clone {
-            None => (),
-            Some(ref clone) => { clone.is_valid()?; }
         };
 
         match &self.osm {
@@ -549,16 +535,16 @@ impl CustomAuth {
             server: String::from("public"),
             webhooks: AuthWebhooks::new(),
             meta: AuthMeta::new(),
-            stats: Some(AuthStats::new()),
-            schema: Some(AuthSchema::new()),
-            auth: Some(AuthAuth::new()),
-            mvt: Some(AuthMVT::new()),
+            stats: AuthStats::new(),
+            schema: AuthSchema::new(),
+            auth: AuthAuth::new(),
+            mvt: AuthMVT::new(),
             user: Some(AuthUser::new()),
             feature: Some(AuthFeature::new()),
             style: Some(AuthStyle::new()),
             delta: Some(AuthDelta::new()),
             bounds: Some(AuthBounds::new()),
-            clone: Some(AuthClone::new()),
+            clone: AuthClone::new(),
             osm: Some(AuthOSM::new())
         }
     }
@@ -572,60 +558,6 @@ impl CustomAuth {
 
     pub fn is_admin(&self, auth: &mut Auth) -> Result<bool, HecateError> {
         auth_met(&Some(String::from("admin")), auth)
-    }
-
-    pub fn allows_stats_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.stats {
-            None => Err(not_authed()),
-            Some(stats) => auth_met(&stats.get, auth)
-        }
-    }
-
-    pub fn allows_stats_bounds(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.stats {
-            None => Err(not_authed()),
-            Some(stats) => auth_met(&stats.bounds, auth)
-        }
-    }
-
-    pub fn allows_mvt_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.mvt {
-            None => Err(not_authed()),
-            Some(mvt) => auth_met(&mvt.get, auth)
-        }
-    }
-
-    pub fn allows_mvt_delete(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.mvt {
-            None => Err(not_authed()),
-            Some(mvt) => auth_met(&mvt.delete, auth)
-        }
-    }
-
-    pub fn allows_mvt_regen(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.mvt {
-            None => Err(not_authed()),
-            Some(mvt) => auth_met(&mvt.regen, auth)
-        }
-    }
-
-    pub fn allows_mvt_meta(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.mvt {
-            None => Err(not_authed()),
-            Some(mvt) => auth_met(&mvt.meta, auth)
-        }
     }
 
     pub fn allows_user_list(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
@@ -745,24 +677,6 @@ impl CustomAuth {
         }
     }
 
-    pub fn allows_clone_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.clone {
-            None => Err(not_authed()),
-            Some(clone) => auth_met(&clone.get, auth)
-        }
-    }
-
-    pub fn allows_clone_query(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.clone {
-            None => Err(not_authed()),
-            Some(clone) => auth_met(&clone.query, auth)
-        }
-    }
-
     pub fn allows_bounds_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
         rw_met(rw, &auth)?;
 
@@ -832,24 +746,6 @@ impl CustomAuth {
         match &self.feature {
             None => Err(not_authed()),
             Some(feature) => auth_met(&feature.history, auth)
-        }
-    }
-
-    pub fn allows_schema_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.schema {
-            None => Err(not_authed()),
-            Some(schema) => auth_met(&schema.get, auth)
-        }
-    }
-
-    pub fn allows_auth_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.auth {
-            None => Err(not_authed()),
-            Some(a) => auth_met(&a.get, auth)
         }
     }
 

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -633,7 +633,7 @@ impl AuthModule for AuthOSM {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct CustomAuth {
-    pub default: Option<String>,
+    pub default: String,
     pub server: String,
     pub meta: AuthMeta,
     pub webhooks: AuthWebhooks,
@@ -653,7 +653,7 @@ pub struct CustomAuth {
 impl AuthModule for CustomAuth {
     fn default() -> Self {
         CustomAuth {
-            default: Some(String::from("public")),
+            default: String::from("public"),
             server: String::from("public"),
             webhooks: AuthWebhooks::default(),
             meta: AuthMeta::default(),
@@ -675,8 +675,8 @@ impl AuthModule for CustomAuth {
         match value {
             None => Ok(Box::new(CustomAuth::default())),
             Some(value) => Ok(Box::new(CustomAuth {
-                default: Some(String::from("public")),
-                server: String::from("public"),
+                default: get_kv("", "default", value)?,
+                server: get_kv("", "server", value)?,
                 webhooks: *AuthWebhooks::parse(value.get("webhooks"))?,
                 meta: *AuthMeta::parse(value.get("meta"))?,
                 stats: *AuthStats::parse(value.get("stats"))?,

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -57,7 +57,7 @@ fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
     }
 }
 
-pub trait SubAuth {
+pub trait AuthModule {
     fn default() -> Self;
     fn parse(value: &Option<serde_json::Value>) -> Self;
     fn is_valid(&self) -> Result<bool, String>;
@@ -69,7 +69,7 @@ pub struct AuthWebhooks {
     pub set: String
 }
 
-impl SubAuth for AuthWebhooks {
+impl AuthModule for AuthWebhooks {
     fn default() -> Self {
         AuthWebhooks {
             get: String::from("admin"),
@@ -78,9 +78,19 @@ impl SubAuth for AuthWebhooks {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthWebhooks {
-            get: String::from("admin"),
-            set: String::from("admin")
+        match value {
+            Some(_) => {
+                AuthWebhooks {
+                    get: String::from("admin"),
+                    set: String::from("admin")
+                }
+            },
+            None => {
+                AuthWebhooks {
+                    get: String::from("disabled"),
+                    set: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -98,7 +108,7 @@ pub struct AuthMeta {
     pub set: String
 }
 
-impl SubAuth for AuthMeta {
+impl AuthModule for AuthMeta {
     fn default() -> Self {
         AuthMeta {
             get: String::from("public"),
@@ -107,9 +117,19 @@ impl SubAuth for AuthMeta {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthMeta {
-            get: String::from("public"),
-            set: String::from("admin")
+        match value {
+            Some(_) => {
+                AuthMeta {
+                    get: String::from("public"),
+                    set: String::from("admin")
+                }
+            },
+            None => {
+                AuthMeta {
+                    get: String::from("disabled"),
+                    set: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -127,7 +147,7 @@ pub struct AuthClone {
     pub query: String
 }
 
-impl SubAuth for AuthClone {
+impl AuthModule for AuthClone {
     fn default() -> Self {
         AuthClone {
             get: String::from("user"),
@@ -136,9 +156,19 @@ impl SubAuth for AuthClone {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthClone {
-            get: String::from("user"),
-            query: String::from("user")
+        match value {
+            Some(_) => {
+                AuthClone {
+                    get: String::from("user"),
+                    query: String::from("user")
+                }
+            },
+            None => {
+                AuthClone {
+                    get: String::from("disabled"),
+                    query: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -155,7 +185,7 @@ pub struct AuthSchema {
     pub get: String
 }
 
-impl SubAuth for AuthSchema {
+impl AuthModule for AuthSchema {
     fn default() -> Self {
         AuthSchema {
             get: String::from("public")
@@ -163,8 +193,17 @@ impl SubAuth for AuthSchema {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthSchema {
-            get: String::from("public")
+        match value {
+            Some(_) => {
+                AuthSchema {
+                    get: String::from("public")
+                }
+            },
+            None => {
+                AuthSchema {
+                    get: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -180,7 +219,7 @@ pub struct AuthStats {
     pub get: String
 }
 
-impl SubAuth for AuthStats {
+impl AuthModule for AuthStats {
     fn default() -> Self {
         AuthStats {
             get: String::from("public"),
@@ -188,8 +227,17 @@ impl SubAuth for AuthStats {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthStats {
-            get: String::from("public"),
+        match value {
+            Some(_) => {
+                AuthStats {
+                    get: String::from("public"),
+                }
+            },
+            None => {
+                AuthStats {
+                    get: String::from("disabled"),
+                }
+            }
         }
     }
 
@@ -205,7 +253,7 @@ pub struct AuthAuth {
     pub get: String
 }
 
-impl SubAuth for AuthAuth {
+impl AuthModule for AuthAuth {
     fn default() -> Self {
         AuthAuth {
             get: String::from("public")
@@ -213,8 +261,17 @@ impl SubAuth for AuthAuth {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthAuth {
-            get: String::from("public")
+        match value {
+            Some(_) => {
+                AuthAuth {
+                    get: String::from("public")
+                }
+            },
+            None => {
+                AuthAuth {
+                    get: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -233,7 +290,7 @@ pub struct AuthMVT {
     pub meta: String
 }
 
-impl SubAuth for AuthMVT {
+impl AuthModule for AuthMVT {
     fn default() -> Self {
         AuthMVT {
             get: String::from("public"),
@@ -244,11 +301,23 @@ impl SubAuth for AuthMVT {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthMVT {
-            get: String::from("public"),
-            delete: String::from("admin"),
-            regen: String::from("user"),
-            meta: String::from("public")
+        match value {
+            Some(_) => {
+                AuthMVT {
+                    get: String::from("public"),
+                    delete: String::from("admin"),
+                    regen: String::from("user"),
+                    meta: String::from("public")
+                }
+            },
+            None => {
+                AuthMVT {
+                    get: String::from("disabled"),
+                    delete: String::from("disabled"),
+                    regen: String::from("disabled"),
+                    meta: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -270,7 +339,7 @@ pub struct AuthUser {
     pub create_session: String
 }
 
-impl SubAuth for AuthUser {
+impl AuthModule for AuthUser {
     fn default() -> Self {
         AuthUser {
             info: String::from("self"),
@@ -281,11 +350,23 @@ impl SubAuth for AuthUser {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthUser {
-            info: String::from("self"),
-            list: String::from("user"),
-            create: String::from("public"),
-            create_session: String::from("self")
+        match value {
+            Some(_) => {
+                AuthUser {
+                    info: String::from("self"),
+                    list: String::from("user"),
+                    create: String::from("public"),
+                    create_session: String::from("self")
+                }
+            },
+            None => {
+                AuthUser {
+                    info: String::from("disabled"),
+                    list: String::from("disabled"),
+                    create: String::from("disabled"),
+                    create_session: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -311,7 +392,7 @@ pub struct AuthStyle {
     pub list: String
 }
 
-impl SubAuth for AuthStyle {
+impl AuthModule for AuthStyle {
     fn default() -> Self {
         AuthStyle {
             create: String::from("self"),
@@ -325,14 +406,29 @@ impl SubAuth for AuthStyle {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthStyle {
-            create: String::from("self"),
-            patch: String::from("self"),
-            set_public: String::from("self"),
-            set_private: String::from("self"),
-            delete: String::from("self"),
-            get: String::from("public"),
-            list: String::from("public")
+        match value {
+            Some(_) => {
+                AuthStyle {
+                    create: String::from("self"),
+                    patch: String::from("self"),
+                    set_public: String::from("self"),
+                    set_private: String::from("self"),
+                    delete: String::from("self"),
+                    get: String::from("public"),
+                    list: String::from("public")
+                }
+            },
+            None => {
+                AuthStyle {
+                    create: String::from("self"),
+                    patch: String::from("self"),
+                    set_public: String::from("self"),
+                    set_private: String::from("self"),
+                    delete: String::from("self"),
+                    get: String::from("public"),
+                    list: String::from("public")
+                }
+            }
         }
     }
 
@@ -355,7 +451,7 @@ pub struct AuthDelta {
     pub list: String,
 }
 
-impl SubAuth for AuthDelta {
+impl AuthModule for AuthDelta {
     fn default() -> Self {
         AuthDelta {
             get: String::from("public"),
@@ -364,9 +460,19 @@ impl SubAuth for AuthDelta {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthDelta {
-            get: String::from("public"),
-            list: String::from("public")
+        match value {
+            Some(_) => {
+                AuthDelta {
+                    get: String::from("public"),
+                    list: String::from("public")
+                }
+            },
+            None => {
+                AuthDelta {
+                    get: String::from("disabled"),
+                    list: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -386,7 +492,7 @@ pub struct AuthFeature {
     pub history: String
 }
 
-impl SubAuth for AuthFeature {
+impl AuthModule for AuthFeature {
     fn default() -> Self {
         AuthFeature {
             force: String::from("none"),
@@ -397,11 +503,23 @@ impl SubAuth for AuthFeature {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthFeature {
-            force: String::from("none"),
-            create: String::from("user"),
-            get: String::from("public"),
-            history: String::from("public")
+        match value {
+            Some(_) => {
+                AuthFeature {
+                    force: String::from("none"),
+                    create: String::from("user"),
+                    get: String::from("public"),
+                    history: String::from("public")
+                }
+            },
+            None => {
+                AuthFeature {
+                    force: String::from("disabled"),
+                    create: String::from("disabled"),
+                    get: String::from("disabled"),
+                    history: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -423,7 +541,7 @@ pub struct AuthBounds {
     pub get: String
 }
 
-impl SubAuth for AuthBounds {
+impl AuthModule for AuthBounds {
     fn default() -> Self {
         AuthBounds {
             list: String::from("public"),
@@ -434,11 +552,23 @@ impl SubAuth for AuthBounds {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthBounds {
-            list: String::from("public"),
-            create: String::from("admin"),
-            delete: String::from("admin"),
-            get: String::from("public")
+        match value {
+            Some(_) => {
+                AuthBounds {
+                    list: String::from("public"),
+                    create: String::from("admin"),
+                    delete: String::from("admin"),
+                    get: String::from("public")
+                }
+            },
+            None => {
+                AuthBounds {
+                    list: String::from("disabled"),
+                    create: String::from("disabled"),
+                    delete: String::from("disabled"),
+                    get: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -458,7 +588,7 @@ pub struct AuthOSM {
     pub create: String
 }
 
-impl SubAuth for AuthOSM {
+impl AuthModule for AuthOSM {
     fn default() -> Self {
         AuthOSM {
             get: String::from("public"),
@@ -467,9 +597,19 @@ impl SubAuth for AuthOSM {
     }
 
     fn parse(value: &Option<serde_json::Value>) -> Self {
-        AuthOSM {
-            get: String::from("public"),
-            create: String::from("user")
+        match value {
+            Some(_) => {
+                AuthOSM {
+                    get: String::from("public"),
+                    create: String::from("user")
+                }
+            },
+            None => {
+                AuthOSM {
+                    get: String::from("disabled"),
+                    create: String::from("disabled")
+                }
+            }
         }
     }
 
@@ -500,7 +640,7 @@ pub struct CustomAuth {
     pub osm: AuthOSM
 }
 
-impl SubAuth for CustomAuth {
+impl AuthModule for CustomAuth {
     fn default() -> Self {
         CustomAuth {
             default: Some(String::from("public")),

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -59,7 +59,7 @@ fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
 
 pub trait AuthModule {
     fn default() -> Self;
-    fn parse(value: &Option<serde_json::Value>) -> Self;
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError>;
     fn is_valid(&self) -> Result<bool, String>;
 }
 
@@ -77,19 +77,19 @@ impl AuthModule for AuthWebhooks {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
-                AuthWebhooks {
+            Some(value) => {
+                Ok(Box::new(AuthWebhooks {
                     get: String::from("admin"),
                     set: String::from("admin")
-                }
+                }))
             },
             None => {
-                AuthWebhooks {
+                Ok(Box::new(AuthWebhooks {
                     get: String::from("disabled"),
                     set: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -116,19 +116,19 @@ impl AuthModule for AuthMeta {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthMeta {
+                Ok(Box::new(AuthMeta {
                     get: String::from("public"),
                     set: String::from("admin")
-                }
+                }))
             },
             None => {
-                AuthMeta {
+                Ok(Box::new(AuthMeta {
                     get: String::from("disabled"),
                     set: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -155,19 +155,19 @@ impl AuthModule for AuthClone {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthClone {
+                Ok(Box::new(AuthClone {
                     get: String::from("user"),
                     query: String::from("user")
-                }
+                }))
             },
             None => {
-                AuthClone {
+                Ok(Box::new(AuthClone {
                     get: String::from("disabled"),
                     query: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -192,17 +192,17 @@ impl AuthModule for AuthSchema {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthSchema {
+                Ok(Box::new(AuthSchema {
                     get: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthSchema {
+                Ok(Box::new(AuthSchema {
                     get: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -226,17 +226,17 @@ impl AuthModule for AuthStats {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthStats {
+                Ok(Box::new(AuthStats {
                     get: String::from("public"),
-                }
+                }))
             },
             None => {
-                AuthStats {
+                Ok(Box::new(AuthStats {
                     get: String::from("disabled"),
-                }
+                }))
             }
         }
     }
@@ -260,17 +260,17 @@ impl AuthModule for AuthAuth {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthAuth {
+                Ok(Box::new(AuthAuth {
                     get: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthAuth {
+                Ok(Box::new(AuthAuth {
                     get: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -300,23 +300,23 @@ impl AuthModule for AuthMVT {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthMVT {
+                Ok(Box::new(AuthMVT {
                     get: String::from("public"),
                     delete: String::from("admin"),
                     regen: String::from("user"),
                     meta: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthMVT {
+                Ok(Box::new(AuthMVT {
                     get: String::from("disabled"),
                     delete: String::from("disabled"),
                     regen: String::from("disabled"),
                     meta: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -349,23 +349,23 @@ impl AuthModule for AuthUser {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthUser {
+                Ok(Box::new(AuthUser {
                     info: String::from("self"),
                     list: String::from("user"),
                     create: String::from("public"),
                     create_session: String::from("self")
-                }
+                }))
             },
             None => {
-                AuthUser {
+                Ok(Box::new(AuthUser {
                     info: String::from("disabled"),
                     list: String::from("disabled"),
                     create: String::from("disabled"),
                     create_session: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -405,10 +405,10 @@ impl AuthModule for AuthStyle {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthStyle {
+                Ok(Box::new(AuthStyle {
                     create: String::from("self"),
                     patch: String::from("self"),
                     set_public: String::from("self"),
@@ -416,10 +416,10 @@ impl AuthModule for AuthStyle {
                     delete: String::from("self"),
                     get: String::from("public"),
                     list: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthStyle {
+                Ok(Box::new(AuthStyle {
                     create: String::from("self"),
                     patch: String::from("self"),
                     set_public: String::from("self"),
@@ -427,7 +427,7 @@ impl AuthModule for AuthStyle {
                     delete: String::from("self"),
                     get: String::from("public"),
                     list: String::from("public")
-                }
+                }))
             }
         }
     }
@@ -459,19 +459,19 @@ impl AuthModule for AuthDelta {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthDelta {
+                Ok(Box::new(AuthDelta {
                     get: String::from("public"),
                     list: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthDelta {
+                Ok(Box::new(AuthDelta {
                     get: String::from("disabled"),
                     list: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -502,23 +502,23 @@ impl AuthModule for AuthFeature {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthFeature {
+                Ok(Box::new(AuthFeature {
                     force: String::from("none"),
                     create: String::from("user"),
                     get: String::from("public"),
                     history: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthFeature {
+                Ok(Box::new(AuthFeature {
                     force: String::from("disabled"),
                     create: String::from("disabled"),
                     get: String::from("disabled"),
                     history: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -551,23 +551,23 @@ impl AuthModule for AuthBounds {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthBounds {
+                Ok(Box::new(AuthBounds {
                     list: String::from("public"),
                     create: String::from("admin"),
                     delete: String::from("admin"),
                     get: String::from("public")
-                }
+                }))
             },
             None => {
-                AuthBounds {
+                Ok(Box::new(AuthBounds {
                     list: String::from("disabled"),
                     create: String::from("disabled"),
                     delete: String::from("disabled"),
                     get: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -596,19 +596,19 @@ impl AuthModule for AuthOSM {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(_) => {
-                AuthOSM {
+                Ok(Box::new(AuthOSM {
                     get: String::from("public"),
                     create: String::from("user")
-                }
+                }))
             },
             None => {
-                AuthOSM {
+                Ok(Box::new(AuthOSM {
                     get: String::from("disabled"),
                     create: String::from("disabled")
-                }
+                }))
             }
         }
     }
@@ -661,24 +661,24 @@ impl AuthModule for CustomAuth {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Self {
-        CustomAuth {
+    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+        Ok(Box::new(CustomAuth {
             default: Some(String::from("public")),
             server: String::from("public"),
-            webhooks: AuthWebhooks::parse(&value),
-            meta: AuthMeta::parse(&value),
-            stats: AuthStats::parse(&value),
-            schema: AuthSchema::parse(&value),
-            auth: AuthAuth::parse(&value),
-            mvt: AuthMVT::parse(&value),
-            user: AuthUser::parse(&value),
-            feature: AuthFeature::parse(&value),
-            style: AuthStyle::parse(&value),
-            delta: AuthDelta::parse(&value),
-            bounds: AuthBounds::parse(&value),
-            clone: AuthClone::parse(&value),
-            osm: AuthOSM::parse(&value)
-        }
+            webhooks: *AuthWebhooks::parse(&value)?,
+            meta: *AuthMeta::parse(&value)?,
+            stats: *AuthStats::parse(&value)?,
+            schema: *AuthSchema::parse(&value)?,
+            auth: *AuthAuth::parse(&value)?,
+            mvt: *AuthMVT::parse(&value)?,
+            user: *AuthUser::parse(&value)?,
+            feature: *AuthFeature::parse(&value)?,
+            style: *AuthStyle::parse(&value)?,
+            delta: *AuthDelta::parse(&value)?,
+            bounds: *AuthBounds::parse(&value)?,
+            clone: *AuthClone::parse(&value)?,
+            osm: *AuthOSM::parse(&value)?
+        }))
 
     }
 

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -683,7 +683,7 @@ impl AuthModule for CustomAuth {
                 schema: *AuthSchema::parse(value.get("schema"))?,
                 auth: *AuthAuth::parse(value.get("auth"))?,
                 mvt: *AuthMVT::parse(value.get("mvt"))?,
-                user: *AuthUser::parse(value.get("mvt"))?,
+                user: *AuthUser::parse(value.get("user"))?,
                 feature: *AuthFeature::parse(value.get("feature"))?,
                 style: *AuthStyle::parse(value.get("style"))?,
                 delta: *AuthDelta::parse(value.get("delta"))?,

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -57,6 +57,16 @@ fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
     }
 }
 
+fn get_kv(key: &str, value: &serde_json::Value) -> Result<String, HecateError> {
+    match value.get(key) {
+        None => Err(HecateError::new(400, format!(""), None)),
+        Some(value) => match value.as_str() {
+            None => Err(HecateError::new(400, format!("{} value must be string", key), None)),
+            Some(value) => Ok(String::from(value))
+        }
+    }
+}
+
 pub trait AuthModule {
     fn default() -> Self;
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError>;
@@ -79,10 +89,10 @@ impl AuthModule for AuthWebhooks {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(value) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthWebhooks {
-                    get: String::from("admin"),
-                    set: String::from("admin")
+                    get: get_kv("get", value)?,
+                    set: get_kv("set", value)?
                 }))
             },
             None => {
@@ -118,10 +128,10 @@ impl AuthModule for AuthMeta {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthMeta {
-                    get: String::from("public"),
-                    set: String::from("admin")
+                    get: get_kv("get", value)?,
+                    set: get_kv("set", value)?
                 }))
             },
             None => {
@@ -157,10 +167,10 @@ impl AuthModule for AuthClone {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthClone {
-                    get: String::from("user"),
-                    query: String::from("user")
+                    get: get_kv("get", value)?,
+                    query: get_kv("query", value)?
                 }))
             },
             None => {
@@ -194,9 +204,9 @@ impl AuthModule for AuthSchema {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthSchema {
-                    get: String::from("public")
+                    get: get_kv("get", value)?
                 }))
             },
             None => {
@@ -228,9 +238,9 @@ impl AuthModule for AuthStats {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthStats {
-                    get: String::from("public"),
+                    get: get_kv("get", value)?
                 }))
             },
             None => {
@@ -262,9 +272,9 @@ impl AuthModule for AuthAuth {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthAuth {
-                    get: String::from("public")
+                    get: get_kv("get", value)?
                 }))
             },
             None => {
@@ -302,12 +312,12 @@ impl AuthModule for AuthMVT {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthMVT {
-                    get: String::from("public"),
-                    delete: String::from("admin"),
-                    regen: String::from("user"),
-                    meta: String::from("public")
+                    get: get_kv("get", value)?,
+                    delete: get_kv("delete", value)?,
+                    regen: get_kv("regen", value)?,
+                    meta: get_kv("meta", value)?
                 }))
             },
             None => {
@@ -351,12 +361,12 @@ impl AuthModule for AuthUser {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthUser {
-                    info: String::from("self"),
-                    list: String::from("user"),
-                    create: String::from("public"),
-                    create_session: String::from("self")
+                    info: get_kv("info", value)?,
+                    list: get_kv("list", value)?,
+                    create: get_kv("create", value)?,
+                    create_session: get_kv("create_session", value)?
                 }))
             },
             None => {
@@ -407,15 +417,15 @@ impl AuthModule for AuthStyle {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthStyle {
-                    create: String::from("self"),
-                    patch: String::from("self"),
-                    set_public: String::from("self"),
-                    set_private: String::from("self"),
-                    delete: String::from("self"),
-                    get: String::from("public"),
-                    list: String::from("public")
+                    create: get_kv("create", value)?,
+                    patch: get_kv("patch", value)?,
+                    set_public: get_kv("set_public", value)?,
+                    set_private: get_kv("set_private", value)?,
+                    delete: get_kv("delete", value)?,
+                    get: get_kv("get", value)?,
+                    list: get_kv("list", value)?
                 }))
             },
             None => {
@@ -461,10 +471,10 @@ impl AuthModule for AuthDelta {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthDelta {
-                    get: String::from("public"),
-                    list: String::from("public")
+                    get: get_kv("get", value)?,
+                    list: get_kv("list", value)?
                 }))
             },
             None => {
@@ -504,12 +514,12 @@ impl AuthModule for AuthFeature {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthFeature {
-                    force: String::from("none"),
-                    create: String::from("user"),
-                    get: String::from("public"),
-                    history: String::from("public")
+                    force: get_kv("force", value)?,
+                    create: get_kv("create", value)?,
+                    get: get_kv("get", value)?,
+                    history: get_kv("history", value)?
                 }))
             },
             None => {
@@ -553,12 +563,12 @@ impl AuthModule for AuthBounds {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthBounds {
-                    list: String::from("public"),
-                    create: String::from("admin"),
-                    delete: String::from("admin"),
-                    get: String::from("public")
+                    list: get_kv("list", value)?,
+                    create: get_kv("create", value)?,
+                    delete: get_kv("delete", value)?,
+                    get: get_kv("get", value)?
                 }))
             },
             None => {
@@ -598,10 +608,10 @@ impl AuthModule for AuthOSM {
 
     fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
-            Some(_) => {
+            Some(ref value) => {
                 Ok(Box::new(AuthOSM {
-                    get: String::from("public"),
-                    create: String::from("user")
+                    get: get_kv("get", value)?,
+                    create: get_kv("create", value)?
                 }))
             },
             None => {

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -15,17 +15,12 @@ pub struct AuthContainer(pub CustomAuth);
 /// This category makes up the majority of endpoints in hecate and is the most
 /// flexible
 ///
-fn is_all(scope_type: &str, scope: &Option<String>) -> Result<bool, String> {
-    match scope {
-        &None => Ok(true),
-        &Some(ref scope_str) => {
-            match scope_str as &str {
-                "public" => Ok(true),
-                "admin" => Ok(true),
-                "user" => Ok(true),
-                _ => Err(format!("Auth Config Error: '{}' must be one of 'public', 'admin', 'user', or null", scope_type)),
-            }
-        }
+fn is_all(scope_type: &str, scope: &String) -> Result<bool, String> {
+    match scope.as_ref() {
+        "public" => Ok(true),
+        "admin" => Ok(true),
+        "user" => Ok(true),
+        _ => Err(format!("Auth Config Error: '{}' must be one of 'public', 'admin', 'user', or null", scope_type)),
     }
 }
 
@@ -36,16 +31,11 @@ fn is_all(scope_type: &str, scope: &Option<String>) -> Result<bool, String> {
 /// not only must the user be logged in but the user can only update their own
 /// data
 ///
-fn is_self(scope_type: &str, scope: &Option<String>) -> Result<bool, String> {
-    match scope {
-        &None => Ok(true),
-        &Some(ref scope_str) => {
-            match scope_str as &str {
-                "self" => Ok(true),
-                "admin" => Ok(true),
-                _ => Err(format!("Auth Config Error: '{}' must be one of 'self', 'admin', or null", scope_type)),
-            }
-        }
+fn is_self(scope_type: &str, scope: &String) -> Result<bool, String> {
+    match scope.as_ref() {
+        "self" => Ok(true),
+        "admin" => Ok(true),
+        _ => Err(format!("Auth Config Error: '{}' must be one of 'self', 'admin', or null", scope_type)),
     }
 }
 
@@ -56,16 +46,11 @@ fn is_self(scope_type: &str, scope: &Option<String>) -> Result<bool, String> {
 /// logged in but can make changes to any feature, including features created
 /// by another user
 ///
-fn is_auth(scope_type: &str, scope: &Option<String>) -> Result<bool, String> {
-    match scope {
-        &None => Ok(true),
-        &Some(ref scope_str) => {
-            match scope_str as &str {
-                "user" => Ok(true),
-                "admin" => Ok(true),
-                _ => Err(format!("Auth Config Error: '{}' must be one of 'user', 'admin', or null", scope_type)),
-            }
-        }
+fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
+    match scope.as_ref() {
+        "user" => Ok(true),
+        "admin" => Ok(true),
+        _ => Err(format!("Auth Config Error: '{}' must be one of 'user', 'admin', or null", scope_type)),
     }
 }
 
@@ -90,8 +75,8 @@ impl AuthWebhooks {
 
 impl ValidAuth for AuthWebhooks {
     fn is_valid(&self) -> Result<bool, String> {
-        is_auth("webhooks::get", &Some(self.get.clone()))?;
-        is_auth("webhooks::set", &Some(self.set.clone()))?;
+        is_auth("webhooks::get", &self.get)?;
+        is_auth("webhooks::set", &self.set)?;
 
         Ok(true)
     }
@@ -114,8 +99,8 @@ impl AuthMeta {
 
 impl ValidAuth for AuthMeta {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("meta::get", &Some(self.get.clone()))?;
-        is_auth("meta::set", &Some(self.set.clone()))?;
+        is_all("meta::get", &self.get)?;
+        is_auth("meta::set", &self.set)?;
 
         Ok(true)
     }
@@ -138,8 +123,8 @@ impl AuthClone {
 
 impl ValidAuth for AuthClone {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("clone::get", &Some(self.get.clone()))?;
-        is_all("clone::query", &Some(self.query.clone()))?;
+        is_all("clone::get", &self.get)?;
+        is_all("clone::query", &self.query)?;
 
         Ok(true)
     }
@@ -160,7 +145,7 @@ impl AuthSchema {
 
 impl ValidAuth for AuthSchema {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("schema::get", &Some(self.get.clone()))?;
+        is_all("schema::get", &self.get)?;
 
         Ok(true)
     }
@@ -181,7 +166,7 @@ impl AuthStats {
 
 impl ValidAuth for AuthStats {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("stats::get", &Some(self.get.clone()))?;
+        is_all("stats::get", &self.get)?;
 
         Ok(true)
     }
@@ -202,7 +187,7 @@ impl AuthAuth {
 
 impl ValidAuth for AuthAuth {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("auth::get", &Some(self.get.clone()))?;
+        is_all("auth::get", &self.get)?;
 
         Ok(true)
     }
@@ -229,10 +214,10 @@ impl AuthMVT {
 
 impl ValidAuth for AuthMVT {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("mvt::get", &Some(self.get.clone()))?;
-        is_all("mvt::regen", &Some(self.regen.clone()))?;
-        is_all("mvt::delete", &Some(self.regen.clone()))?;
-        is_all("mvt::meta", &Some(self.meta.clone()))?;
+        is_all("mvt::get", &self.get)?;
+        is_all("mvt::regen", &self.regen)?;
+        is_all("mvt::delete", &self.regen)?;
+        is_all("mvt::meta", &self.meta)?;
 
         Ok(true)
     }
@@ -240,19 +225,19 @@ impl ValidAuth for AuthMVT {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthUser {
-    pub info: Option<String>,
-    pub list: Option<String>,
-    pub create: Option<String>,
-    pub create_session: Option<String>
+    pub info: String,
+    pub list: String,
+    pub create: String,
+    pub create_session: String
 }
 
 impl AuthUser {
     fn new() -> Self {
         AuthUser {
-            info: Some(String::from("self")),
-            list: Some(String::from("user")),
-            create: Some(String::from("public")),
-            create_session: Some(String::from("self"))
+            info: String::from("self"),
+            list: String::from("user"),
+            create: String::from("public"),
+            create_session: String::from("self")
         }
     }
 }
@@ -271,25 +256,25 @@ impl ValidAuth for AuthUser {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthStyle {
-    pub create: Option<String>,
-    pub patch: Option<String>,
-    pub set_public: Option<String>,
-    pub set_private: Option<String>,
-    pub delete: Option<String>,
-    pub get: Option<String>,
-    pub list: Option<String>
+    pub create: String,
+    pub patch: String,
+    pub set_public: String,
+    pub set_private: String,
+    pub delete: String,
+    pub get: String,
+    pub list: String
 }
 
 impl AuthStyle {
     fn new() -> Self {
         AuthStyle {
-            create: Some(String::from("self")),
-            patch: Some(String::from("self")),
-            set_public: Some(String::from("self")),
-            set_private: Some(String::from("self")),
-            delete: Some(String::from("self")),
-            get: Some(String::from("public")),
-            list: Some(String::from("public"))
+            create: String::from("self"),
+            patch: String::from("self"),
+            set_public: String::from("self"),
+            set_private: String::from("self"),
+            delete: String::from("self"),
+            get: String::from("public"),
+            list: String::from("public")
         }
     }
 }
@@ -310,15 +295,15 @@ impl ValidAuth for AuthStyle {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthDelta {
-    pub get: Option<String>,
-    pub list: Option<String>,
+    pub get: String,
+    pub list: String,
 }
 
 impl AuthDelta {
     fn new() -> Self {
         AuthDelta {
-            get: Some(String::from("public")),
-            list: Some(String::from("public"))
+            get: String::from("public"),
+            list: String::from("public")
         }
     }
 }
@@ -334,19 +319,19 @@ impl ValidAuth for AuthDelta {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthFeature {
-    pub force: Option<String>,
-    pub create: Option<String>,
-    pub get: Option<String>,
-    pub history: Option<String>
+    pub force: String,
+    pub create: String,
+    pub get: String,
+    pub history: String
 }
 
 impl AuthFeature {
     fn new() -> Self {
         AuthFeature {
-            force: Some(String::from("none")),
-            create: Some(String::from("user")),
-            get: Some(String::from("public")),
-            history: Some(String::from("public"))
+            force: String::from("none"),
+            create: String::from("user"),
+            get: String::from("public"),
+            history: String::from("public")
         }
     }
 }
@@ -364,19 +349,19 @@ impl ValidAuth for AuthFeature {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthBounds {
-    pub list: Option<String>,
-    pub create: Option<String>,
-    pub delete: Option<String>,
-    pub get: Option<String>
+    pub list: String,
+    pub create: String,
+    pub delete: String,
+    pub get: String
 }
 
 impl AuthBounds {
     fn new() -> Self {
         AuthBounds {
-            list: Some(String::from("public")),
-            create: Some(String::from("admin")),
-            delete: Some(String::from("admin")),
-            get: Some(String::from("public"))
+            list: String::from("public"),
+            create: String::from("admin"),
+            delete: String::from("admin"),
+            get: String::from("public")
         }
     }
 }
@@ -394,15 +379,15 @@ impl ValidAuth for AuthBounds {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AuthOSM {
-    pub get: Option<String>,
-    pub create: Option<String>
+    pub get: String,
+    pub create: String
 }
 
 impl AuthOSM {
     fn new() -> Self {
         AuthOSM {
-            get: Some(String::from("public")),
-            create: Some(String::from("user"))
+            get: String::from("public"),
+            create: String::from("user")
         }
     }
 }
@@ -426,54 +411,30 @@ pub struct CustomAuth {
     pub mvt: AuthMVT,
     pub schema: AuthSchema,
     pub auth: AuthAuth,
-    pub user: Option<AuthUser>,
-    pub feature: Option<AuthFeature>,
-    pub style: Option<AuthStyle>,
-    pub delta: Option<AuthDelta>,
-    pub bounds: Option<AuthBounds>,
+    pub user: AuthUser,
+    pub feature: AuthFeature,
+    pub style: AuthStyle,
+    pub delta: AuthDelta,
+    pub bounds: AuthBounds,
     pub clone: AuthClone,
-    pub osm: Option<AuthOSM>
+    pub osm: AuthOSM
 }
 
 impl ValidAuth for CustomAuth {
     fn is_valid(&self) -> Result<bool, String> {
-        is_all("server", &Some(self.server.clone()))?;
+        is_all("server", &self.server)?;
 
         &self.meta.is_valid()?;
         &self.mvt.is_valid()?;
         &self.stats.is_valid()?;
         &self.clone.is_valid()?;
         &self.schema.is_valid()?;
-
-        match &self.user {
-            None => (),
-            Some(ref user) => { user.is_valid()?; }
-        };
-
-        match &self.feature {
-            None => (),
-            Some(ref feature) => { feature.is_valid()?; }
-        };
-
-        match &self.style {
-            None => (),
-            Some(ref style) => { style.is_valid()?; }
-        };
-
-        match &self.delta {
-            None => (),
-            Some(ref delta) => { delta.is_valid()?; }
-        };
-
-        match &self.bounds {
-            None => (),
-            Some(ref bounds) => { bounds.is_valid()?; }
-        };
-
-        match &self.osm {
-            None => (),
-            Some(ref osm) => { osm.is_valid()?; }
-        };
+        &self.user.is_valid()?;
+        &self.feature.is_valid()?;
+        &self.style.is_valid()?;
+        &self.delta.is_valid()?;
+        &self.bounds.is_valid()?;
+        &self.osm.is_valid()?;
 
         Ok(true)
     }
@@ -491,7 +452,7 @@ pub fn rw_met(rw: RW, auth: &Auth) -> Result<(), HecateError> {
 /// Determines whether the current auth state meets or exceeds the
 /// requirements of an endpoint
 ///
-fn auth_met(required: &Option<String>, auth: &mut Auth) -> Result<bool, HecateError> {
+fn auth_met(required: &Option<String>, auth: &Auth) -> Result<bool, HecateError> {
     match required {
         None => Err(not_authed()),
         Some(req) => match req.as_ref() {
@@ -539,13 +500,13 @@ impl CustomAuth {
             schema: AuthSchema::new(),
             auth: AuthAuth::new(),
             mvt: AuthMVT::new(),
-            user: Some(AuthUser::new()),
-            feature: Some(AuthFeature::new()),
-            style: Some(AuthStyle::new()),
-            delta: Some(AuthDelta::new()),
-            bounds: Some(AuthBounds::new()),
+            user: AuthUser::new(),
+            feature: AuthFeature::new(),
+            style: AuthStyle::new(),
+            delta: AuthDelta::new(),
+            bounds: AuthBounds::new(),
             clone: AuthClone::new(),
-            osm: Some(AuthOSM::new())
+            osm: AuthOSM::new()
         }
     }
 
@@ -556,214 +517,7 @@ impl CustomAuth {
     }
 
 
-    pub fn is_admin(&self, auth: &mut Auth) -> Result<bool, HecateError> {
+    pub fn is_admin(&self, auth: &Auth) -> Result<bool, HecateError> {
         auth_met(&Some(String::from("admin")), auth)
-    }
-
-    pub fn allows_user_list(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.user {
-            None => Err(not_authed()),
-            Some(user) => auth_met(&user.list, auth)
-        }
-    }
-
-    pub fn allows_user_create(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.user {
-            None => Err(not_authed()),
-            Some(user) => auth_met(&user.create, auth)
-        }
-    }
-
-    pub fn allows_user_info(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.user {
-            None => Err(not_authed()),
-            Some(user) => auth_met(&user.info, auth)
-        }
-    }
-
-    pub fn allows_user_create_session(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.user {
-            None => Err(not_authed()),
-            Some(user) => auth_met(&user.create_session, auth)
-        }
-    }
-
-    pub fn allows_style_create(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.create, auth)
-        }
-    }
-
-    pub fn allows_style_patch(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.patch, auth)
-        }
-    }
-
-    pub fn allows_style_set_public(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.set_public, auth)
-        }
-    }
-
-    pub fn allows_style_set_private(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.set_private, auth)
-        }
-    }
-
-    pub fn allows_style_delete(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.delete, auth)
-        }
-    }
-
-    pub fn allows_style_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.get, auth)
-        }
-    }
-
-    pub fn allows_style_list(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.style {
-            None => Err(not_authed()),
-            Some(style) => auth_met(&style.list, auth)
-        }
-    }
-
-    pub fn allows_delta_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.delta {
-            None => Err(not_authed()),
-            Some(delta) => auth_met(&delta.get, auth)
-        }
-    }
-
-    pub fn allows_delta_list(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.delta {
-            None => Err(not_authed()),
-            Some(delta) => auth_met(&delta.list, auth)
-        }
-    }
-
-    pub fn allows_bounds_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.bounds {
-            None => Err(not_authed()),
-            Some(bounds) => auth_met(&bounds.get, auth)
-        }
-    }
-
-    pub fn allows_bounds_create(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.bounds {
-            None => Err(not_authed()),
-            Some(bounds) => auth_met(&bounds.create, auth)
-        }
-    }
-
-    pub fn allows_bounds_delete(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.bounds {
-            None => Err(not_authed()),
-            Some(bounds) => auth_met(&bounds.delete, auth)
-        }
-    }
-
-    pub fn allows_bounds_list(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.bounds {
-            None => Err(not_authed()),
-            Some(bounds) => auth_met(&bounds.list, auth)
-        }
-    }
-
-    pub fn allows_feature_create(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.feature {
-            None => Err(not_authed()),
-            Some(feature) => auth_met(&feature.create, auth)
-        }
-    }
-
-    pub fn allows_feature_force(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.feature {
-            None => Err(not_authed()),
-            Some(feature) => auth_met(&feature.force, auth)
-        }
-    }
-
-    pub fn allows_feature_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.feature {
-            None => Err(not_authed()),
-            Some(feature) => auth_met(&feature.get, auth)
-        }
-    }
-
-    pub fn allows_feature_history(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.feature {
-            None => Err(not_authed()),
-            Some(feature) => auth_met(&feature.history, auth)
-        }
-    }
-
-    pub fn allows_osm_get(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.osm {
-            None => Err(not_authed()),
-            Some(osm) => auth_met(&osm.get, auth)
-        }
-    }
-
-    pub fn allows_osm_create(&self, auth: &mut Auth, rw: RW) -> Result<bool, HecateError> {
-        rw_met(rw, &auth)?;
-
-        match &self.osm {
-            None => Err(not_authed()),
-            Some(osm) => auth_met(&osm.create, auth)
-        }
     }
 }

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -57,8 +57,8 @@ fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
     }
 }
 
-fn get_kv(scope: &str, key: &str, value: &serde_json::Value) -> Result<String, HecateError> {
-    match value.get(key) {
+fn get_kv(scope: &str, key: &str, kv: &serde_json::Value) -> Result<String, HecateError> {
+    match kv.get(key) {
         None => Err(HecateError::new(400, format!("{}::{} has no value", scope, key), None)),
         Some(value) => match value.as_str() {
             None => Err(HecateError::new(400, format!("{}::{} value must be string", scope, key), None)),

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -702,10 +702,11 @@ impl AuthModule for CustomAuth {
 }
 
 impl CustomAuth {
-    pub fn to_json(&self) -> serde_json::value::Value {
-        let json_auth = serde_json::from_str(serde_json::to_string(&self).unwrap().as_str()).unwrap();
-
-        json_auth
+    pub fn to_json(&self) -> Result<serde_json::value::Value, HecateError> {
+        match serde_json::to_value(&self) {
+            Ok(value) => Ok(value),
+            Err(err) => Err(HecateError::new(500, String::from("Could not create Auth JSON"), Some(err.to_string())))
+        }
     }
 
 

--- a/src/auth/config.rs
+++ b/src/auth/config.rs
@@ -57,11 +57,11 @@ fn is_auth(scope_type: &str, scope: &String) -> Result<bool, String> {
     }
 }
 
-fn get_kv(key: &str, value: &serde_json::Value) -> Result<String, HecateError> {
+fn get_kv(scope: &str, key: &str, value: &serde_json::Value) -> Result<String, HecateError> {
     match value.get(key) {
-        None => Err(HecateError::new(400, format!(""), None)),
+        None => Err(HecateError::new(400, format!("{}::{} has no value", scope, key), None)),
         Some(value) => match value.as_str() {
-            None => Err(HecateError::new(400, format!("{} value must be string", key), None)),
+            None => Err(HecateError::new(400, format!("{}::{} value must be string", scope, key), None)),
             Some(value) => Ok(String::from(value))
         }
     }
@@ -69,7 +69,7 @@ fn get_kv(key: &str, value: &serde_json::Value) -> Result<String, HecateError> {
 
 pub trait AuthModule {
     fn default() -> Self;
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError>;
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError>;
     fn is_valid(&self) -> Result<bool, String>;
 }
 
@@ -87,12 +87,12 @@ impl AuthModule for AuthWebhooks {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthWebhooks {
-                    get: get_kv("get", value)?,
-                    set: get_kv("set", value)?
+                    get: get_kv("webhooks", "get", value)?,
+                    set: get_kv("webhooks", "set", value)?
                 }))
             },
             None => {
@@ -126,12 +126,12 @@ impl AuthModule for AuthMeta {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthMeta {
-                    get: get_kv("get", value)?,
-                    set: get_kv("set", value)?
+                    get: get_kv("meta", "get", value)?,
+                    set: get_kv("meta", "set", value)?
                 }))
             },
             None => {
@@ -165,12 +165,12 @@ impl AuthModule for AuthClone {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthClone {
-                    get: get_kv("get", value)?,
-                    query: get_kv("query", value)?
+                    get: get_kv("clone", "get", value)?,
+                    query: get_kv("clone", "query", value)?
                 }))
             },
             None => {
@@ -202,11 +202,11 @@ impl AuthModule for AuthSchema {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthSchema {
-                    get: get_kv("get", value)?
+                    get: get_kv("schema", "get", value)?
                 }))
             },
             None => {
@@ -236,11 +236,11 @@ impl AuthModule for AuthStats {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthStats {
-                    get: get_kv("get", value)?
+                    get: get_kv("stats", "get", value)?
                 }))
             },
             None => {
@@ -270,11 +270,11 @@ impl AuthModule for AuthAuth {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthAuth {
-                    get: get_kv("get", value)?
+                    get: get_kv("auth", "get", value)?
                 }))
             },
             None => {
@@ -310,14 +310,14 @@ impl AuthModule for AuthMVT {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthMVT {
-                    get: get_kv("get", value)?,
-                    delete: get_kv("delete", value)?,
-                    regen: get_kv("regen", value)?,
-                    meta: get_kv("meta", value)?
+                    get: get_kv("mvt", "get", value)?,
+                    delete: get_kv("mvt", "delete", value)?,
+                    regen: get_kv("mvt", "regen", value)?,
+                    meta: get_kv("mvt", "meta", value)?
                 }))
             },
             None => {
@@ -359,14 +359,14 @@ impl AuthModule for AuthUser {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthUser {
-                    info: get_kv("info", value)?,
-                    list: get_kv("list", value)?,
-                    create: get_kv("create", value)?,
-                    create_session: get_kv("create_session", value)?
+                    info: get_kv("user", "info", value)?,
+                    list: get_kv("user", "list", value)?,
+                    create: get_kv("user", "create", value)?,
+                    create_session: get_kv("user", "create_session", value)?
                 }))
             },
             None => {
@@ -415,17 +415,17 @@ impl AuthModule for AuthStyle {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthStyle {
-                    create: get_kv("create", value)?,
-                    patch: get_kv("patch", value)?,
-                    set_public: get_kv("set_public", value)?,
-                    set_private: get_kv("set_private", value)?,
-                    delete: get_kv("delete", value)?,
-                    get: get_kv("get", value)?,
-                    list: get_kv("list", value)?
+                    create: get_kv("style", "create", value)?,
+                    patch: get_kv("style", "patch", value)?,
+                    set_public: get_kv("style", "set_public", value)?,
+                    set_private: get_kv("style", "set_private", value)?,
+                    delete: get_kv("style", "delete", value)?,
+                    get: get_kv("style", "get", value)?,
+                    list: get_kv("style", "list", value)?
                 }))
             },
             None => {
@@ -469,12 +469,12 @@ impl AuthModule for AuthDelta {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthDelta {
-                    get: get_kv("get", value)?,
-                    list: get_kv("list", value)?
+                    get: get_kv("delta", "get", value)?,
+                    list: get_kv("delta", "list", value)?
                 }))
             },
             None => {
@@ -512,14 +512,14 @@ impl AuthModule for AuthFeature {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthFeature {
-                    force: get_kv("force", value)?,
-                    create: get_kv("create", value)?,
-                    get: get_kv("get", value)?,
-                    history: get_kv("history", value)?
+                    force: get_kv("feature", "force", value)?,
+                    create: get_kv("feature", "create", value)?,
+                    get: get_kv("feature", "get", value)?,
+                    history: get_kv("feature", "history", value)?
                 }))
             },
             None => {
@@ -561,14 +561,14 @@ impl AuthModule for AuthBounds {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthBounds {
-                    list: get_kv("list", value)?,
-                    create: get_kv("create", value)?,
-                    delete: get_kv("delete", value)?,
-                    get: get_kv("get", value)?
+                    list: get_kv("bounds", "list", value)?,
+                    create: get_kv("bounds", "create", value)?,
+                    delete: get_kv("bounds", "delete", value)?,
+                    get: get_kv("bounds", "get", value)?
                 }))
             },
             None => {
@@ -606,12 +606,12 @@ impl AuthModule for AuthOSM {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
         match value {
             Some(ref value) => {
                 Ok(Box::new(AuthOSM {
-                    get: get_kv("get", value)?,
-                    create: get_kv("create", value)?
+                    get: get_kv("osm", "get", value)?,
+                    create: get_kv("osm", "create", value)?
                 }))
             },
             None => {
@@ -671,24 +671,27 @@ impl AuthModule for CustomAuth {
         }
     }
 
-    fn parse(value: &Option<serde_json::Value>) -> Result<Box<Self>, HecateError> {
-        Ok(Box::new(CustomAuth {
-            default: Some(String::from("public")),
-            server: String::from("public"),
-            webhooks: *AuthWebhooks::parse(&value)?,
-            meta: *AuthMeta::parse(&value)?,
-            stats: *AuthStats::parse(&value)?,
-            schema: *AuthSchema::parse(&value)?,
-            auth: *AuthAuth::parse(&value)?,
-            mvt: *AuthMVT::parse(&value)?,
-            user: *AuthUser::parse(&value)?,
-            feature: *AuthFeature::parse(&value)?,
-            style: *AuthStyle::parse(&value)?,
-            delta: *AuthDelta::parse(&value)?,
-            bounds: *AuthBounds::parse(&value)?,
-            clone: *AuthClone::parse(&value)?,
-            osm: *AuthOSM::parse(&value)?
-        }))
+    fn parse(value: Option<&serde_json::Value>) -> Result<Box<Self>, HecateError> {
+        match value {
+            None => Ok(Box::new(CustomAuth::default())),
+            Some(value) => Ok(Box::new(CustomAuth {
+                default: Some(String::from("public")),
+                server: String::from("public"),
+                webhooks: *AuthWebhooks::parse(value.get("webhooks"))?,
+                meta: *AuthMeta::parse(value.get("meta"))?,
+                stats: *AuthStats::parse(value.get("stats"))?,
+                schema: *AuthSchema::parse(value.get("schema"))?,
+                auth: *AuthAuth::parse(value.get("auth"))?,
+                mvt: *AuthMVT::parse(value.get("mvt"))?,
+                user: *AuthUser::parse(value.get("mvt"))?,
+                feature: *AuthFeature::parse(value.get("feature"))?,
+                style: *AuthStyle::parse(value.get("style"))?,
+                delta: *AuthDelta::parse(value.get("delta"))?,
+                bounds: *AuthBounds::parse(value.get("bounds"))?,
+                clone: *AuthClone::parse(value.get("clone"))?,
+                osm: *AuthOSM::parse(value.get("osm"))?
+            }))
+        }
 
     }
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,7 @@ use actix_web::http::header::{HeaderName, HeaderValue};
 pub mod config;
 pub mod middleware;
 pub use config::AuthContainer;
-pub use config::SubAuth;
+pub use config::AuthModule;
 pub use config::CustomAuth;
 pub use config::RW;
 use crate::user::token::Scope;

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -26,6 +26,42 @@ pub struct Auth {
     pub scope: Scope
 }
 
+pub fn check(rule: &String, rw: config::RW, auth: &Auth) -> Result<(), HecateError> {
+    config::rw_met(rw, &auth)?;
+
+    match rule.as_ref() {
+        "public" => Ok(()),
+        "admin" => {
+            if auth.uid.is_none() || auth.access.is_none() {
+                return Err(config::not_authed());
+            } else if auth.access == Some(String::from("admin")) {
+                return Ok(());
+            } else {
+                return Err(config::not_authed());
+            }
+        },
+        "user" => {
+            if auth.uid.is_some() {
+                return Ok(());
+            } else {
+                return Err(config::not_authed());
+            }
+        },
+        "self" => {
+            //Note: This ensures the user is validated,
+            //it is up to the parent caller to ensure
+            //the UID of 'self' matches the requested resource
+
+            if auth.uid.is_some() {
+                return Ok(());
+            } else {
+                return Err(config::not_authed());
+            }
+        },
+        _ => Err(config::not_authed())
+    }
+}
+
 impl Auth {
     pub fn new() -> Self {
         Auth {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,7 +5,7 @@ use actix_web::http::header::{HeaderName, HeaderValue};
 pub mod config;
 pub mod middleware;
 pub use config::AuthContainer;
-pub use config::ValidAuth;
+pub use config::SubAuth;
 pub use config::CustomAuth;
 pub use config::RW;
 use crate::user::token::Scope;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use actix_web::{web, web::Json, App, HttpResponse, HttpRequest, HttpServer, midd
 use futures::{Future, Stream, future::Either};
 use geojson::GeoJson;
 use crate::{
-    auth::ValidAuth,
+    auth::SubAuth,
     err::HecateError,
     db::*
 };
@@ -52,7 +52,7 @@ pub fn start(
     auth: Option<auth::CustomAuth>
 ) {
     let auth_rules: auth::CustomAuth = match auth {
-        None => auth::CustomAuth::new(),
+        None => auth::CustomAuth::default(),
         Some(auth) => {
             match auth.is_valid() {
                 Err(err_msg) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1273,7 +1273,7 @@ fn auth_get(
 ) -> Result<Json<serde_json::Value>, HecateError> {
     auth::check(&auth_rules.0.auth.get, auth::RW::Read, &auth)?;
 
-    Ok(Json(auth_rules.0.to_json()))
+    Ok(Json(auth_rules.0.to_json()?))
 }
 
 fn stats_get(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use actix_web::{web, web::Json, App, HttpResponse, HttpRequest, HttpServer, midd
 use futures::{Future, Stream, future::Either};
 use geojson::GeoJson;
 use crate::{
-    auth::SubAuth,
+    auth::AuthModule,
     err::HecateError,
     db::*
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,11 @@ pub fn start(
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    let default = match auth_rules.0.default {
-        String::from("public")  => auth::AuthDefault::Public,
-        String::from("user") => auth::AuthDefault::User,
-        String::from("admin") =>  auth::AuthDefault::Admin,
-        _ => > panic!("Invalid 'domain' value in custom auth")
+    let default = match &*auth_rules.0.default {
+        "public"  => auth::AuthDefault::Public,
+        "user" => auth::AuthDefault::User,
+        "admin" => auth::AuthDefault::Admin,
+        _ => panic!("Invalid 'domain' value in custom auth")
     };
 
     HttpServer::new(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,19 +77,14 @@ pub fn start(
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    let default = match auth_rules.0.default {
-        None => auth::AuthDefault::Public,
-        Some(ref default) => {
-            if default == &String::from("public") {
-                auth::AuthDefault::Public
-            } else if default == &String::from("user") {
-                auth::AuthDefault::User
-            } else if default == &String::from("admin") {
-                auth::AuthDefault::Admin
-            } else {
-                panic!("Invalid 'domain' value in custom auth");
-            }
-        }
+    let default = if auth_rules.0.default == String::from("public") {
+            auth::AuthDefault::Public
+        } else if auth_rules.0.default == String::from("user") {
+            auth::AuthDefault::User
+        } else if auth_rules.0.default == String::from("admin") {
+            auth::AuthDefault::Admin
+        } else {
+            panic!("Invalid 'domain' value in custom auth");
     };
 
     HttpServer::new(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,14 +77,11 @@ pub fn start(
     std::env::set_var("RUST_LOG", "actix_web=info");
     env_logger::init();
 
-    let default = if auth_rules.0.default == String::from("public") {
-            auth::AuthDefault::Public
-        } else if auth_rules.0.default == String::from("user") {
-            auth::AuthDefault::User
-        } else if auth_rules.0.default == String::from("admin") {
-            auth::AuthDefault::Admin
-        } else {
-            panic!("Invalid 'domain' value in custom auth");
+    let default = match auth_rules.0.default {
+        String::from("public")  => auth::AuthDefault::Public,
+        String::from("user") => auth::AuthDefault::User,
+        String::from("admin") =>  auth::AuthDefault::Admin,
+        _ => > panic!("Invalid 'domain' value in custom auth")
     };
 
     HttpServer::new(move || {

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -160,8 +160,7 @@ mod test {
                     "get": "user"
                 },
                 "stats": {
-                    "get": "user",
-                    "bounds": "user"
+                    "get": "user"
                 },
                 "mvt": {
                     "get": "user",

--- a/tests/auth_closed.rs
+++ b/tests/auth_closed.rs
@@ -149,13 +149,11 @@ mod test {
                 "default": "public",
                 "server": "public",
                 "webhooks": {
-                    "list": "user",
-                    "update": "user",
-                    "delete": "user"
+                    "get": "user",
+                    "set": "user"
                 },
                 "meta": {
                     "get": "user",
-                    "list": "user",
                     "set": "user"
                 },
                 "schema": {

--- a/tests/auth_disabled.rs
+++ b/tests/auth_disabled.rs
@@ -1,0 +1,130 @@
+extern crate reqwest;
+extern crate postgres;
+#[macro_use] extern crate serde_json;
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::env;
+    use std::io::prelude::*;
+    use postgres::{Connection, TlsMode};
+    use std::process::Command;
+    use std::time::Duration;
+    use std::thread;
+    use reqwest;
+    use serde_json::value::Value;
+
+    #[test]
+    fn auth_disabled() {
+        {
+            let conn = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None).unwrap();
+
+            conn.execute("
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE
+                    pg_stat_activity.datname = 'hecate'
+                    AND pid <> pg_backend_pid();
+            ", &[]).unwrap();
+
+            conn.execute("
+                DROP DATABASE IF EXISTS hecate;
+            ", &[]).unwrap();
+
+            conn.execute("
+                CREATE DATABASE hecate;
+            ", &[]).unwrap();
+
+            let conn = Connection::connect("postgres://postgres@localhost:5432/hecate", TlsMode::None).unwrap();
+
+            let mut file = File::open("./src/schema.sql").unwrap();
+            let mut table_sql = String::new();
+            file.read_to_string(&mut table_sql).unwrap();
+            conn.batch_execute(&*table_sql).unwrap();
+        }
+
+        let mut server = Command::new("cargo").args(&[
+            "run",
+            "--",
+            "--auth", env::current_dir().unwrap().join("tests/fixtures/auth.disabled.json").to_str().unwrap()
+        ]).spawn().unwrap();
+        thread::sleep(Duration::from_secs(1));
+
+        {
+            let client = reqwest::Client::new();
+            let mut resp = client.get("http://localhost:8000/api/auth").send().unwrap();
+
+            let resp_value: Value = resp.json().unwrap();
+
+            assert_eq!(resp_value, json!({
+                "default": "public",
+                "server": "disabled",
+                "webhooks": {
+                    "get": "disabled",
+                    "set": "disabled"
+                },
+                "meta": {
+                    "get": "disabled",
+                    "set": "disabled"
+                },
+                "schema": {
+                    "get": "disabled"
+                },
+                "stats": {
+                    "get": "disabled"
+                },
+                "mvt": {
+                    "get": "disabled",
+                    "regen": "disabled",
+                    "delete": "disabled",
+                    "meta": "disabled"
+                },
+                "user": {
+                    "info": "disabled",
+                    "list": "disabled",
+                    "create": "disabled",
+                    "create_session": "disabled"
+                },
+                "style": {
+                    "create": "disabled",
+                    "patch": "disabled",
+                    "set_public": "disabled",
+                    "set_private": "disabled",
+                    "delete": "disabled",
+                    "get": "disabled",
+                    "list": "disabled"
+                },
+                "delta": {
+                    "get": "disabled",
+                    "list": "disabled"
+                },
+                "feature": {
+                    "force": "disabled",
+                    "create": "disabled",
+                    "get": "disabled",
+                    "history": "disabled"
+                },
+                "bounds": {
+                    "list": "disabled",
+                    "create": "disabled",
+                    "delete": "disabled",
+                    "get": "disabled"
+                },
+                "osm": {
+                    "get": "disabled",
+                    "create": "disabled"
+                },
+                "clone": {
+                    "get": "disabled",
+                    "query": "disabled"
+                },
+                "auth": {
+                    "get": "public"
+                }
+            }));
+            assert!(resp.status().is_success());
+        }
+
+        server.kill().unwrap();
+    }
+}

--- a/tests/fixtures/auth.closed.json
+++ b/tests/fixtures/auth.closed.json
@@ -13,8 +13,7 @@
         "get": "user"
     },
     "stats": {
-        "get": "user",
-        "bounds": "user"
+        "get": "user"
     },
     "mvt": {
         "get": "user",

--- a/tests/fixtures/auth.closed.json
+++ b/tests/fixtures/auth.closed.json
@@ -2,13 +2,11 @@
     "default": "public",
     "server": "public",
     "webhooks": {
-        "list": "user",
-        "delete": "user",
-        "update": "user"
+        "set": "user",
+        "get": "user"
     },
     "meta": {
         "get": "user",
-        "list": "user",
         "set": "user"
     },
     "schema": {

--- a/tests/fixtures/auth.default.json
+++ b/tests/fixtures/auth.default.json
@@ -2,13 +2,11 @@
     "default": "user",
     "server": "public",
     "webhooks": {
-        "list": "public",
-        "delete": "public",
-        "update": "public"
+        "set": "public",
+        "get": "public"
     },
     "meta": {
         "get": "public",
-        "list": "public",
         "set": "user"
     },
     "schema": {

--- a/tests/fixtures/auth.default.json
+++ b/tests/fixtures/auth.default.json
@@ -13,8 +13,7 @@
         "get": "public"
     },
     "stats": {
-        "get": "public",
-        "bounds": "public"
+        "get": "public"
     },
     "mvt": {
         "get": "public",

--- a/tests/fixtures/auth.disabled.json
+++ b/tests/fixtures/auth.disabled.json
@@ -1,0 +1,7 @@
+{
+    "default": "public",
+    "server": "disabled",
+    "auth": {
+        "get": "public"
+    }
+}

--- a/tests/fixtures/auth.meta.json
+++ b/tests/fixtures/auth.meta.json
@@ -1,13 +1,11 @@
 {
     "server": "user",
     "webhooks": {
-        "list": "user",
-        "delete": "user",
-        "modify": "user"
+        "set": "user",
+        "get": "user"
     },
     "meta": {
         "get": "user",
-        "list": "user",
         "set": "user"
     },
     "schema": {


### PR DESCRIPTION
### Context

Our auth situation has been a mess of boilerplate that came from the early days in an effort to let serde_json handle the heavy lifting of reading the config files into the structs.

This rewrites the auth handling internally to be simpler, more easily extendible, and less error/bug prone

### Tasks
- [x] Rewrite Auth struct to remove boilerplate `allows_*`  methods and allow direct auth checks
- [x] Simplify webhook permissions to `get/set`
- [x] Simplify meta permission to `get/set`
- [x] Simplify stats permission to `get`
- [x] Create JSON -> Struct trait for each section for manual JSON parsing and better error messages
- [x] Ensure `disabled` type is respected

cc/ @ingalls
