### PR TITLE
Token Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 # Version History
 
+## v0.85.0
+
+- :tada: [UI] Add ability to list & manage user's auth tokens
+- :tada: Add token listing endpoint
+- :rocket: Give each token a unique ID that it can be deleted with
+- :rocket: Add ability to create non-expiring API tokens
+
 ## v0.84.0
 
 - :tada: Add properties to VT output

--- a/README.md
+++ b/README.md
@@ -856,6 +856,98 @@ of this guide
 curl -X GET 'http://localhost:8000/api/auth'
 ```
 
+---
+
+#### `GET` `/api/user/tokens`
+
+Return a JSON array containing all of the tokens associated with the requesting user's account
+
+Note: The token itself will only ever be returned once, when it is created
+
+*Example*
+
+```bash
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/tokens
+```
+
+---
+
+#### `GET` `/api/user/token/<token|id>`
+
+Retrieve metadata about a given token
+
+Note: The token itself will only ever be returned once, when it is created
+
+*Options*
+
+| Option    | Notes |
+| :-------: | ----- |
+| `<id>`    | `REQUIRED` UUID of the token to fetch |
+| `<token>` | `REQUIRED` The Token itself to fetch |
+
+Note: Either the `<id>` or the `<token>` must be used.
+
+*Example*
+
+```bash
+curl -X GET \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/token/123-456-789'
+```
+
+---
+
+#### `POST` `/api/user/token`
+
+Given a JSON object, create a new API token
+
+*Body*
+
+| Option    | Notes |
+| :-------: | ----- |
+| `name`    | `OPTIOANL` The name of the token to create|
+| `scope`   | `OPTIONAL` `full` or `read` (default) |
+| `hours`   | `OPTIONAL` Number of hours until the token should expire, `undefined` for permanent tokens |
+
+*Example*
+
+```bash
+curl
+    -X POST
+    -H "Content-Type: application/json" \
+    -d '{ "name": "Token Name", "hours": 10, "scope": "full" }' \
+    -u 'username:password' \
+    'http://localhost:8000/api/user/token'
+
+```
+
+---
+
+#### `DELETE` `/api/user/token/<token|id>`
+
+Permanently delete a given API token
+
+*Options*
+
+| Option    | Notes |
+| :-------: | ----- |
+| `<id>`    | `REQUIRED` UUID of the token to fetch |
+| `<token>` | `REQUIRED` The Token itself to fetch |
+
+Note: Either the `<id>` or the `<token>` must be used.
+
+
+*Example*
+
+```bash
+curl
+    -X DELETE
+    -u 'username:password' \
+    'http://localhost:8000/api/user/token/123-456-789'
+```
+
 </details>
 
 ---

--- a/hecate/src/auth/mod.rs
+++ b/hecate/src/auth/mod.rs
@@ -413,7 +413,10 @@ impl Auth {
                     users
                 WHERE
                     token = $1
-                    AND now() < expiry
+                    AND (
+                        expiry IS NULL
+                        OR now() < expiry
+                    )
                     AND users_tokens.uid = users.id
             ", &[ &self.token.as_ref().unwrap() ]) {
                 Ok(res) => {

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -698,7 +698,7 @@ fn user_create_session(
     }).then(|res: Result<user::Token, actix_threadpool::BlockingError<HecateError>>| match res {
         Ok(token) => {
 
-            let cookie = actix_http::http::Cookie::build("session", token.token)
+            let cookie = actix_http::http::Cookie::build("session", token.token()?)
                 .path("/")
                 .http_only(true)
                 .max_age(HOURS * 60 * 60)

--- a/hecate/src/lib.rs
+++ b/hecate/src/lib.rs
@@ -752,11 +752,11 @@ fn user_delete_session(
 }
 
 fn user_tokens(
-    conn: web::Data<DbReadWrite>,
+    conn: web::Data<DbReplica>,
     auth: auth::Auth,
     auth_rules: web::Data<auth::AuthContainer>
 ) -> Result<Json<serde_json::Value>, HecateError> {
-    auth::check(&auth_rules.0.user.info, auth::RW::Full, &auth)?;
+    auth::check(&auth_rules.0.user.info, auth::RW::Read, &auth)?;
 
     let uid = match auth.uid {
         Some(uid) => uid,

--- a/hecate/src/schema.sql
+++ b/hecate/src/schema.sql
@@ -48,11 +48,12 @@ CREATE TABLE users (
 
 DROP TABLE IF EXISTS users_tokens;
 CREATE TABLE users_tokens (
-    name        TEXT,
-    uid         BIGINT,
+    name        TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    uid         BIGINT NOT NULL,
     token       TEXT PRIMARY KEY,
     expiry      TIMESTAMP,
-    scope       TEXT
+    scope       TEXT NOT NULL
 );
 
 DROP TABLE IF EXISTS geo;

--- a/hecate/src/schema.sql
+++ b/hecate/src/schema.sql
@@ -49,7 +49,6 @@ CREATE TABLE users (
 DROP TABLE IF EXISTS users_tokens;
 CREATE TABLE users_tokens (
     name        TEXT NOT NULL,
-    type        TEXT NOT NULL,
     uid         BIGINT NOT NULL,
     token       TEXT PRIMARY KEY,
     expiry      TIMESTAMP,

--- a/hecate/src/schema.sql
+++ b/hecate/src/schema.sql
@@ -3,6 +3,7 @@ BEGIN;
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DROP TABLE IF EXISTS webhooks;
 CREATE TABLE webhooks (
@@ -48,6 +49,7 @@ CREATE TABLE users (
 
 DROP TABLE IF EXISTS users_tokens;
 CREATE TABLE users_tokens (
+    id          UUID UNIQUE NOT NULL,
     name        TEXT NOT NULL,
     uid         BIGINT NOT NULL,
     token       TEXT PRIMARY KEY,

--- a/hecate/src/user/token.rs
+++ b/hecate/src/user/token.rs
@@ -106,20 +106,21 @@ impl Token {
                 id::TEXT,
                 name,
                 uid,
-                token,
                 expiry::TEXT,
                 scope
             FROM
                 users_tokens
             WHERE
-                uid = $1,
-                token = $2
+                uid = $1
+                AND (
+                    token = $2
+                    OR id = $2
+                )
         ", &[ &uid, &token ]) {
             Ok(res) => {
                 let id: String = res.get(0).get(0);
                 let name: String = res.get(0).get(1);
                 let uid: i64 = res.get(0).get(2);
-                let token: String = res.get(0).get(3);
                 let expiry: Option<String> = res.get(0).get(4);
                 let scope: String = res.get(0).get(5);
 
@@ -128,7 +129,7 @@ impl Token {
                     _ => Scope::Read
                 };
 
-                Ok(Token::new(Some(id), name, uid, Some(token), expiry, scope))
+                Ok(Token::new(Some(id), name, uid, None, expiry, scope))
             },
             Err(err) => Err(HecateError::from_db(err))
         }

--- a/hecate/src/user/token.rs
+++ b/hecate/src/user/token.rs
@@ -75,7 +75,7 @@ impl Token {
                             $1,
                             $2,
                             md5(random()::TEXT),
-                            {hours}
+                            now() + ($3::TEXT)::INTERVAL,
                             $4
                         )
                         RETURNING

--- a/hecate/src/user/token.rs
+++ b/hecate/src/user/token.rs
@@ -103,10 +103,10 @@ impl Token {
     pub fn get(conn: &impl postgres::GenericConnection, uid: i64, token: &str) -> Result<Self, HecateError> {
         match conn.query("
             SELECT
-                id::TEXT,
+                id::TEXT AS id,
                 name,
                 uid,
-                expiry::TEXT,
+                expiry::TEXT AS expiry,
                 scope
             FROM
                 users_tokens
@@ -114,15 +114,15 @@ impl Token {
                 uid = $1
                 AND (
                     token = $2
-                    OR id = $2
+                    OR id::TEXT = $2
                 )
         ", &[ &uid, &token ]) {
             Ok(res) => {
                 let id: String = res.get(0).get(0);
                 let name: String = res.get(0).get(1);
                 let uid: i64 = res.get(0).get(2);
-                let expiry: Option<String> = res.get(0).get(4);
-                let scope: String = res.get(0).get(5);
+                let expiry: Option<String> = res.get(0).get(3);
+                let scope: String = res.get(0).get(4);
 
                 let scope = match scope.as_str() {
                     "full" => Scope::Full,

--- a/hecate/tests/token.rs
+++ b/hecate/tests/token.rs
@@ -291,6 +291,39 @@ mod test {
                 assert_eq!(json_body.as_array().unwrap().len(), 1);
             }
 
+            { // Get Token By Token
+                let client = reqwest::Client::new();
+                let mut resp = client.get(format!("http://0.0.0.0:8000/api/user/token/{}", token).as_str())
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                println!("{:?}", json_body);
+                assert_eq!(json_body["name"], json!("No Expiry"));
+                assert_eq!(json_body["scope"], json!("Full"));
+                assert_eq!(json_body["id"], json!(token_id));
+            }
+
+            { // Get Token By Token ID
+                let client = reqwest::Client::new();
+                let mut resp = client.get(format!("http://0.0.0.0:8000/api/user/token/{}", token_id).as_str())
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                assert_eq!(json_body["name"], json!("No Expiry"));
+                assert_eq!(json_body["scope"], json!("Full"));
+                assert_eq!(json_body["id"], json!(token_id));
+            }
+
             { // Access the capabilities (READ scope) endpoint without token
                 let resp = reqwest::get("http://0.0.0.0:8000/api/capabilities").unwrap();
                 assert_eq!(resp.status().as_u16(), 401);

--- a/hecate/tests/token.rs
+++ b/hecate/tests/token.rs
@@ -57,113 +57,196 @@ mod test {
             ", &[]).unwrap();
         }
 
-        { // Attempt to access default server
-            let mut resp = reqwest::get("http://0.0.0.0:8000/").unwrap();
-            assert_eq!(resp.status().as_u16(), 200);
-            assert_eq!(resp.text().unwrap(), "Hello World!");
+        {
+            { // Attempt to access default server
+                let mut resp = reqwest::get("http://0.0.0.0:8000/").unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+                assert_eq!(resp.text().unwrap(), "Hello World!");
+            }
+
+            let token: String;
+
+            { // Create Token
+                let client = reqwest::Client::new();
+
+                let mut resp = client.post("http://0.0.0.0:8000/api/user/token")
+                    .body(r#"{
+                        "name": "JOSM Token",
+                        "hours": 5
+                    }"#)
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                assert_eq!(json_body["name"], json!("JOSM Token"));
+                assert_eq!(json_body["uid"], json!(1));
+
+                assert!(resp.status().is_success());
+
+                token = json_body["token"].as_str().unwrap().to_string();
+            }
+
+            { // Access the capabilities (READ scope) endpoint without token
+                let resp = reqwest::get("http://0.0.0.0:8000/api/capabilities").unwrap();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+
+            { // Access the capabilities (READ scope) endpoint with token
+                let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { // Access the feature create (FULL scope) endpoint without token
+                let client = reqwest::Client::new();
+                let resp = client.post("http://0.0.0.0:8000/api/data/feature")
+                    .body(r#"{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    }"#)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+
+            { // Access the feature create (FULL scope) endpoint with token
+                let client = reqwest::Client::new();
+                let resp = client.post(format!("http://0.0.0.0:8000/token/{}/api/data/feature", token).as_str())
+                    .body(r#"{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    }"#)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 401);
+            }
+
+            { // Access the feature create (FULL scope) endpoint with token and basic auth
+                let client = reqwest::Client::new();
+                let resp = client.post(format!("http://0.0.0.0:8000/token/{}/api/data/feature", token).as_str())
+                    .body(r#"{
+                        "type": "Feature",
+                        "action": "create",
+                        "message": "Creating a Point",
+                        "properties": { "number": "123" },
+                        "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
+                    }"#)
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { // Access the Tokens List
+                let client = reqwest::Client::new();
+                println!("http://0.0.0.0:8000/token/{}/api/user/tokens", token);
+                let mut resp = client.get(format!("http://0.0.0.0:8000/token/{}/api/user/tokens", token).as_str())
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+
+                let json_body: serde_json::value::Value = resp.json().unwrap();
+
+                assert_eq!(json_body.as_array().unwrap().len(), 1);
+            }
+
+            { // Delete Token
+                let client = reqwest::Client::new();
+
+                let resp = client.delete(format!("http://0.0.0.0:8000/api/user/token/{}", token).as_str())
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
+
+                assert_eq!(resp.status().as_u16(), 200);
+            }
+
+            { // Access the capabilities endpoint with token
+                let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
+                assert_eq!(resp.status().as_u16(), 401);
+            }
         }
 
-        let token: String;
+        {
+            let token_id: String;
 
-        { // Create Token
-            let client = reqwest::Client::new();
+            { // Create Full Token
+                let client = reqwest::Client::new();
 
-            let mut resp = client.post("http://0.0.0.0:8000/api/user/token")
-                .body(r#"{
-                    "name": "JOSM Token",
-                    "hours": 5
-                }"#)
-                .basic_auth("ingalls", Some("yeahehyeah"))
-                .header(reqwest::header::CONTENT_TYPE, "application/json")
-                .send()
-                .unwrap();
+                let mut resp = client.post("http://0.0.0.0:8000/api/user/token")
+                    .body(r#"{
+                        "name": "Full Token",
+                        "scope": "full",
+                        "hours": 1
+                    }"#)
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .send()
+                    .unwrap();
 
-            let json_body: serde_json::value::Value = resp.json().unwrap();
+                let json_body: serde_json::value::Value = resp.json().unwrap();
 
-            assert_eq!(json_body["name"], json!("Access Token"));
-            assert_eq!(json_body["uid"], json!(1));
+                assert_eq!(json_body["name"], json!("Full Token"));
+                assert_eq!(json_body["uid"], json!(1));
 
-            assert!(resp.status().is_success());
+                token_id = json_body["id"].as_str().unwrap().to_string();
 
-            token = json_body["token"].as_str().unwrap().to_string();
-        }
+                assert!(resp.status().is_success());
+            }
 
-        { // Access the capabilities (READ scope) endpoint without token
-            let resp = reqwest::get("http://0.0.0.0:8000/api/capabilities").unwrap();
-            assert_eq!(resp.status().as_u16(), 401);
-        }
+            { // Access the Tokens List
+                let client = reqwest::Client::new();
+                let mut resp = client.get("http://0.0.0.0:8000/api/user/tokens")
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
 
-        { // Access the capabilities (READ scope) endpoint with token
-            let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
-            assert_eq!(resp.status().as_u16(), 200);
-        }
+                assert_eq!(resp.status().as_u16(), 200);
 
-        { // Access the feature create (FULL scope) endpoint without token
-            let client = reqwest::Client::new();
-            let resp = client.post("http://0.0.0.0:8000/api/data/feature")
-                .body(r#"{
-                    "type": "Feature",
-                    "action": "create",
-                    "message": "Creating a Point",
-                    "properties": { "number": "123" },
-                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
-                }"#)
-                .header(reqwest::header::CONTENT_TYPE, "application/json")
-                .send()
-                .unwrap();
+                let json_body: serde_json::value::Value = resp.json().unwrap();
 
-            assert_eq!(resp.status().as_u16(), 401);
-        }
+                assert_eq!(json_body.as_array().unwrap().len(), 1);
+            }
 
-        { // Access the feature create (FULL scope) endpoint with token
-            let client = reqwest::Client::new();
-            let resp = client.post(format!("http://0.0.0.0:8000/token/{}/api/data/feature", token).as_str())
-                .body(r#"{
-                    "type": "Feature",
-                    "action": "create",
-                    "message": "Creating a Point",
-                    "properties": { "number": "123" },
-                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
-                }"#)
-                .header(reqwest::header::CONTENT_TYPE, "application/json")
-                .send()
-                .unwrap();
+            { // Delete Token Using UUID
+                let client = reqwest::Client::new();
 
-            assert_eq!(resp.status().as_u16(), 401);
-        }
+                let resp = client.delete(format!("http://0.0.0.0:8000/api/user/token/{}", token_id).as_str())
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
 
-        { // Access the feature create (FULL scope) endpoint with token and basic auth
-            let client = reqwest::Client::new();
-            let resp = client.post(format!("http://0.0.0.0:8000/token/{}/api/data/feature", token).as_str())
-                .body(r#"{
-                    "type": "Feature",
-                    "action": "create",
-                    "message": "Creating a Point",
-                    "properties": { "number": "123" },
-                    "geometry": { "type": "Point", "coordinates": [ 0, 0 ] }
-                }"#)
-                .basic_auth("ingalls", Some("yeahehyeah"))
-                .header(reqwest::header::CONTENT_TYPE, "application/json")
-                .send()
-                .unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+            }
 
-            assert_eq!(resp.status().as_u16(), 200);
-        }
+            { // Access the Tokens List
+                let client = reqwest::Client::new();
+                let mut resp = client.get("http://0.0.0.0:8000/api/user/tokens")
+                    .basic_auth("ingalls", Some("yeahehyeah"))
+                    .send()
+                    .unwrap();
 
-        { // Delete Token
-            let client = reqwest::Client::new();
+                assert_eq!(resp.status().as_u16(), 200);
 
-            let resp = client.delete(format!("http://0.0.0.0:8000/api/user/token/{}", token).as_str())
-                .basic_auth("ingalls", Some("yeahehyeah"))
-                .send()
-                .unwrap();
+                let json_body: serde_json::value::Value = resp.json().unwrap();
 
-            assert_eq!(resp.status().as_u16(), 200);
-        }
-
-        { // Access the capabilities endpoint with token
-            let resp = reqwest::get(format!("http://0.0.0.0:8000/token/{}/api/capabilities", token).as_str()).unwrap();
-            assert_eq!(resp.status().as_u16(), 401);
+                assert_eq!(json_body.as_array().unwrap().len(), 0);
+            }
         }
 
         server.kill().unwrap();

--- a/hecate/tests/user_session.rs
+++ b/hecate/tests/user_session.rs
@@ -84,7 +84,7 @@ mod test {
                 .unwrap();
 
             let json_body: serde_json::value::Value = token_resp.json().unwrap();
-            assert_eq!(json_body["name"], json!("Access Token"));
+            assert_eq!(json_body["name"], json!("JOSM Token"));
             assert_eq!(json_body["uid"], json!(1));
             assert!(token_resp.status().is_success());
             token = json_body["token"].as_str().unwrap().to_string();

--- a/hecate_ui/src/App.vue
+++ b/hecate_ui/src/App.vue
@@ -94,7 +94,7 @@
             <user :auth='auth' :user='user_id' v-on:close='modal = false' />
         </template>
         <template v-else-if='modal === "self"'>
-            <self :auth='auth' v-on:close='modal = false' />
+            <self v-on:error='handler($event)' :auth='auth' v-on:close='modal = false' />
         </template>
         <template v-else-if='modal === "settings"'>
             <settings v-on:error='handler($event)' v-on:close='settings_close' :auth='auth'/>

--- a/hecate_ui/src/main.js
+++ b/hecate_ui/src/main.js
@@ -201,8 +201,8 @@ window.hecate = {
             delete: function(token, cb) {
                 if (!token) return cb(new Error('Token ID required'));
 
-                fetch(`${window.location.protocol}//${window.location.host}/api/user/token`, {
-                    method: 'POST',
+                fetch(`${window.location.protocol}//${window.location.host}/api/user/token/${token}`, {
+                    method: 'DELETE',
                     credentials: 'same-origin',
                     headers: new Headers({
                         'Content-Type': 'application/json'

--- a/hecate_ui/src/main.js
+++ b/hecate_ui/src/main.js
@@ -147,6 +147,37 @@ window.hecate = {
             });
         }
     },
+    user: {
+        info: function(cb) {
+            fetch(`${window.location.protocol}//${window.location.host}/api/user/info`, {
+                method: 'GET',
+                credentials: 'same-origin'
+            }).then((response) => {
+                if (response.status !== 200) return res2err(response, cb);
+                return response.json();
+            }).then((users) => {
+                return cb(null, users);
+            }).catch((err) => {
+                return cb(err);
+            });
+        },
+        tokens: function(cb) {
+            fetch(`${window.location.protocol}//${window.location.host}/api/user/tokens`, {
+                method: 'GET',
+                credentials: 'same-origin'
+            }).then((response) => {
+                if (response.status !== 200) return res2err(response, cb);
+                return response.json();
+            }).then((tokens) => {
+                return cb(null, tokens.map((token) => {
+                    token.expiry = token.expiry.replace(/\..*$/, '');
+                    return token;
+                }));
+            }).catch((err) => {
+                return cb(err);
+            });
+        }
+    },
     users: {
         list: function(filter, cb) {
             fetch(`${window.location.protocol}//${window.location.host}/api/users?filter=${filter}`, {

--- a/hecate_ui/src/main.js
+++ b/hecate_ui/src/main.js
@@ -170,12 +170,53 @@ window.hecate = {
                 return response.json();
             }).then((tokens) => {
                 return cb(null, tokens.map((token) => {
-                    token.expiry = token.expiry.replace(/\..*$/, '');
+                    token.scope = token.scope.toLowerCase();
+                    if (token.expiry) {
+                        token.expiry = token.expiry.replace(/\..*$/, '');
+                    }
                     return token;
                 }));
             }).catch((err) => {
                 return cb(err);
             });
+        },
+        token: {
+            create: function(token, cb) {
+                fetch(`${window.location.protocol}//${window.location.host}/api/user/token`, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: new Headers({
+                        'Content-Type': 'application/json'
+                    }),
+                    body: JSON.stringify(token)
+                }).then((response) => {
+                    if (response.status !== 200) return res2err(response, cb);
+                    return response.json();
+                }).then((token) => {
+                    return cb(null, token);
+                }).catch((err) => {
+                    return cb(err);
+                });
+            },
+            delete: function(token, cb) {
+                if (!token) return cb(new Error('Token ID required'));
+
+                fetch(`${window.location.protocol}//${window.location.host}/api/user/token`, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: new Headers({
+                        'Content-Type': 'application/json'
+                    }),
+                    body: JSON.stringify(token)
+                }).then((response) => {
+                    if (response.status !== 200) return res2err(response, cb);
+                    return response.json();
+                }).then((token) => {
+                    return cb(null, token);
+                }).catch((err) => {
+                    return cb(err);
+                });
+            }
         }
     },
     users: {

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -278,7 +278,11 @@ export default {
         setToken: function() {
             if (this.token.id) this.$emit('error', new Error('Cannot alter existing token'));
 
-            window.hecate.user.token.create(this.token, (err, token) => {
+            window.hecate.user.token.create({
+                name: this.token.name,
+                hours: this.token.hours ? parseInt(this.token.hours) : undefined,
+                scope: this.token.scope
+            }, (err, token) => {
                 if (err) return this.$emit('error', err);
 
                 this.token.id = token.id;

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -79,6 +79,12 @@
                         </template>
                         <template v-else-if='mode === "tokens"'>
                             <div class='grid grid--gut12 col col--12 pt12' style="max-height: 600px;">
+                                <div class='col col--12 grid pb6'>
+                                    <div class='col--2'>Scope</div>
+                                    <div class='col--5'>Token Name</div>
+                                    <div class='col--5'><span class='fr'>Expiry</span></div>
+                                </div>
+
                                 <div class='col col--12 h240 scroll-auto'>
                                     <template v-for='token of tokens'>
                                         <div class='col col--12'>
@@ -88,7 +94,7 @@
                                                 </div>
                                                 <div class='col--5' v-text='token.name'></div>
                                                 <div class='col--5'>
-                                                <span class='fr' v-text='token.expiry'></span>
+                                                    <span class='fr' v-text='token.expiry'></span>
                                                 </div>
                                             </div>
                                         </div>

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -21,55 +21,79 @@
                     </div>
                 </template>
                 <template v-else>
-                    <div class='grid grid--gut12 col col--12'>
+                    <div class='col col--12'>
                         <div class='col col--12 txt-m txt-bold'>
                             Account Settings
                             <button @click='close' class='fr btn round bg-white color-black bg-darken25-on-hover'><svg class='icon'><use href='#icon-close'/></svg></button>
                         </div>
 
                         <div class='py6 col col--12 border--gray-light border-b'>
-                            <span class='txt-m'>Personal Info</span>
+                            <button class='btn btn--s round' :class='mainbtn' @click='mode = "main"'>Personal Info</button>
+                            <button class='btn btn--s round' :class='tokensbtn' @click='mode = "tokens"'>Access Tokens</button>
                         </div>
 
-                        <div class='col col--12 py12'>
-                            <label>Username</label>
-                            <input disabled class='input mb6' v-model='user.username' placeholder='Username' />
+                        <template v-if='mode === "main"'>
+                            <div class='grid grid--gut12 col col--12'>
+                                <div class='col col--12 py12'>
+                                    <label>Username</label>
+                                    <input disabled class='input mb6' v-model='user.username' placeholder='Username' />
 
-                            <label>Email</label>
-                            <input disabled class='input mb6' v-model='user.email' placeholder='Email' />
-                        </div>
+                                    <label>Email</label>
+                                    <input disabled class='input mb6' v-model='user.email' placeholder='Email' />
+                                </div>
 
-                        <div class='py6 col col--12 border--gray-light border-b'>
-                            <span class='txt-m'>Account Security</span>
-                        </div>
+                                <div class='py6 col col--12 border--gray-light border-b'>
+                                    <span class='txt-m'>Account Security</span>
+                                </div>
 
-                        <div class='col col--12 py12'>
-                            <label>Current Password</label>
-                            <input type=password v-model='pw.current' class='input mb6' placeholder='Current Password' />
-                        </div>
-                        <div class='col col--5'>
-                            <label>New Password</label>
-                            <input type=password v-model='pw.newPass' class='input mb6' placeholder='New Password' />
-                        </div>
-                        <div class='col col--5'>
-                            <label>Confirm New Password</label>
-                            <input type=password v-model='pw.newConf' class='input mb6' placeholder='New Password' />
-                        </div>
-                        <div class='col col--2'>
-                            <button @click='setPassword' style='margin-top: 22px;' class='btn'>Update</button>
-                        </div>
+                                <div class='col col--12 py12'>
+                                    <label>Current Password</label>
+                                    <input type=password v-model='pw.current' class='input mb6' placeholder='Current Password' />
+                                </div>
+                                <div class='col col--5'>
+                                    <label>New Password</label>
+                                    <input type=password v-model='pw.newPass' class='input mb6' placeholder='New Password' />
+                                </div>
+                                <div class='col col--5'>
+                                    <label>Confirm New Password</label>
+                                    <input type=password v-model='pw.newConf' class='input mb6' placeholder='New Password' />
+                                </div>
+                                <div class='col col--2'>
+                                    <button @click='setPassword' style='margin-top: 22px;' class='btn'>Update</button>
+                                </div>
 
-                        <div class='py6 col col--12 border--gray-light border-b'>
-                            <span class='txt-m'>JOSM URL</span>
-                        </div>
+                                <div class='py6 col col--12 border--gray-light border-b'>
+                                    <span class='txt-m'>JOSM URL</span>
+                                </div>
 
-                        <template v-if='url || !auth || auth && auth.default === "public"'>
-                            <pre class='pre my6 w-full'><code class='w-full' v-text='url || defaultJOSM()'></code></pre>
+                                <template v-if='url || !auth || auth && auth.default === "public"'>
+                                    <pre class='pre my6 w-full'><code class='w-full' v-text='url || defaultJOSM()'></code></pre>
+                                </template>
+                                <template v-else>
+                                    <div class='col col--12 py12'>
+                                        Generate an authenticated URL
+                                        <button @click='createUrl' class='fr btn round btn--stroke'>Generate</button>
+                                    </div>
+                                </template>
+                            </div>
                         </template>
-                        <template v-else>
-                            <div class='col col--12 py12'>
-                                Generate an authenticated URL
-                                <button @click='createUrl' class='fr btn round btn--stroke'>Generate</button>
+                        <template v-else-if='mode === "tokens"'>
+                            <div class='grid grid--gut12 col col--12 pt12' style="max-height: 600px;">
+                                <div class='col col--12 h240 scroll-auto'>
+                                    <template v-for='token of tokens'>
+                                        <div class='col col--12'>
+                                           <div class='grid col h30 bg-gray-faint-on-hover cursor-pointer round'>
+                                                <div class='col--2'>
+                                                    <span class='ml6 bg-blue-faint color-blue inline-block px6 py3 my3 mx3 txt-xs txt-bold round' v-text="token.scope"></span>
+                                                </div>
+                                                <div class='col--5' v-text='token.name'></div>
+                                                <div class='col--5'>
+                                                <span class='fr' v-text='token.expiry'></span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </template>
+                                </div>
                             </div>
                         </template>
                     </div>
@@ -86,7 +110,9 @@ export default {
         return {
             url: '',
             user: false,
+            tokens: [],
             error: false,
+            mode: 'main',
             pw: {
                 current: '',
                 newPass: '',
@@ -96,6 +122,21 @@ export default {
     },
     mounted: function() {
         this.getSelf();
+        this.getTokens();
+    },
+    computed: {
+        mainbtn: function() {
+            return {
+                'color-blue': this.mode === 'main' ? false : true,
+                'btn--white': this.mode === 'main' ? false : true
+            };
+        },
+        tokensbtn: function() {
+            return {
+                'color-blue': this.mode === 'tokens' ? false : true,
+                'btn--white': this.mode === 'tokens' ? false : true
+            };
+        }
     },
     methods: {
         close: function() {
@@ -170,21 +211,19 @@ export default {
 
         },
         getSelf: function() {
-            fetch(`${window.location.protocol}//${window.location.host}/api/user/info`, {
-                method: 'GET',
-                credentials: 'same-origin'
-            }).then((response) => {
-                if (response.status !== 200) {
-                    return this.error = response.status + ':' + response.statusText;
-                }
+            window.hecate.user.info((err, user) => {
+                if (err) return this.$emit('error', err);
 
-                return response.json();
-            }).then((user) => {
                 this.user = user;
-            }).catch((err) => {
-                this.error = err.message;
             });
         },
+        getTokens: function() {
+            window.hecate.user.tokens((err, tokens) => {
+                if (err) return this.$emit('error', err);
+
+                this.tokens = tokens;
+            });
+        }
     },
     render: h => h(App),
     props: ['auth']

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -303,28 +303,16 @@ export default {
 
         },
         createUrl: function() {
-            fetch(`${window.location.protocol}//${window.location.host}/api/user/token`, {
-                method: 'POST',
-                credentials: 'same-origin',
-                headers: new Headers({
-                    'Content-Type': 'application/json'
-                }),
-                body: JSON.stringify({
-                    name: 'JOSM Token',
-                    hours: 336
-                })
-            }).then((response) => {
-                if (response.status !== 200) {
-                    return this.error = response.status + ':' + response.statusText;
-                }
+            window.hecate.user.token.create({
+                name: 'JOSM Token',
+                hours: 336,
+                scope: 'read'
+            }, (err, token) => {
+                if (err) return this.$emit('error', err);
 
-                return response.json();
-            }).then((user) => {
-                this.url = `${window.location.origin}/token/${user.token}/api`;
-            }).catch((err) => {
-                this.error = err.message;
+                this.url = `${window.location.origin}/token/${token.token}/api`;
+                this.getTokens();
             });
-
         },
         setPassword: function() {
             if (!this.pw.newPass || !this.pw.newConf || !this.pw.current) {

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -124,13 +124,13 @@
                                 <div class='col col--12 grid grid--gut12'>
                                     <div class='col col--8'>
                                         <label>Token Name</label>
-                                        <input class='input mb6' v-model='token.name' placeholder='Token Name' />
+                                        <input :disabled='!!token.id' class='input mb6' v-model='token.name' placeholder='Token Name' />
                                     </div>
 
                                     <div class='col col--4'>
                                         <label>Scope</label>
                                         <div class='w-full select-container'>
-                                            <select v-model='token.scope' class='select'>
+                                            <select :disabled='!!token.id' v-model='token.scope' class='select'>
                                                 <option>read</option>
                                                 <option>full</option>
                                             </select>
@@ -143,7 +143,7 @@
                                     <div class='col col--6'>
                                         <label>Expiration</label>
                                         <div class='w-full select-container'>
-                                            <select v-model='token.expiry' class='select'>
+                                            <select :disabled='!!token.id' v-model='token.expiry' class='select'>
                                                 <option>none</option>
                                                 <option>expiration</option>
                                             </select>
@@ -161,23 +161,35 @@
                                 <template v-else>
                                     <div class='col col--6'>
                                         <label>Expiration</label>
-                                        <input class='input mb6' v-model='token.expiry' placeholder='Expiration' />
+                                        <input class='input mb6' :disabled='!!token.id' v-model='token.expiry' placeholder='Expiration' />
                                     </div>
                                     <div class='col col--6'>
                                     </div>
                                 </template>
 
-                                <div class='col col--6 py12'>
-                                    <button @click='mode = "tokens"' class='btn btn--stroke round'>Cancel</button>
-                                </div>
-                                <div class='col col--6 py12'>
-                                    <template v-if='!token.id'>
-                                        <button @click='setToken' class='fr btn round mr12'>Create Token</button>
-                                    </template>
-                                    <template v-else>
-                                        <button @click='deleteToken(token.id)' class='fr btn btn--red round mr12'>Delete Token</button>
-                                    </template>
-                                </div>
+                                <template v-if='token.token'>
+                                    <div class='col col--12 pt24 pb12'>
+                                        Your token has been created. Copy this token now as it will only be shown now
+
+                                        <pre class='pre my6 w-full'><code class='w-full' v-text='token.token'></code></pre>
+                                    </div>
+                                    <div class='col col--12'>
+                                        <button @click='mode = "tokens"' class='fr btn btn--stroke round mr12'>Done</button>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    <div class='col col--6 py12'>
+                                        <button @click='mode = "tokens"' class='btn btn--stroke round'>Cancel</button>
+                                    </div>
+                                    <div class='col col--6 py12'>
+                                        <template v-if='!token.id'>
+                                            <button @click='setToken' class='fr btn round mr12'>Create Token</button>
+                                        </template>
+                                        <template v-else>
+                                            <button @click='deleteToken(token.id)' class='fr btn btn--red round mr12'>Delete Token</button>
+                                        </template>
+                                    </div>
+                                </template>
                             </div>
                         </template>
                     </div>
@@ -264,12 +276,16 @@ export default {
             }
         },
         setToken: function() {
-            if (!this.token.id) this.$emit('error', new Error('Cannot alter existing token'));
+            if (this.token.id) this.$emit('error', new Error('Cannot alter existing token'));
 
             window.hecate.user.token.create(this.token, (err, token) => {
                 if (err) return this.$emit('error', err);
 
-                console.error(token);
+                this.token.id = token.id;
+                this.token.token = token.token;
+                this.token.expiry = token.expiry;
+
+                this.getTokens();
             });
         },
         deleteToken: function(token) {

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -29,7 +29,7 @@
 
                         <div class='py6 col col--12 border--gray-light border-b'>
                             <template v-if='mode === "token"'>
-                                <template v-if='token.id'>
+                                <template v-if='!token.id'>
                                     <span>Create a Token</span>
                                 </template>
                                 <template v-else>

--- a/hecate_ui/src/modals/Self.vue
+++ b/hecate_ui/src/modals/Self.vue
@@ -29,7 +29,10 @@
 
                         <div class='py6 col col--12 border--gray-light border-b'>
                             <button class='btn btn--s round' :class='mainbtn' @click='mode = "main"'>Personal Info</button>
+                            <button class='btn btn--s round' :class='securitybtn' @click='mode = "security"'>Account Security</button>
                             <button class='btn btn--s round' :class='tokensbtn' @click='mode = "tokens"'>Access Tokens</button>
+
+                            <button @click='token(false)' v-if='mode === "tokens"' class='btn btn--stroke fr round'><svg class='icon'><use href='#icon-plus'/></svg></button>
                         </div>
 
                         <template v-if='mode === "main"'>
@@ -40,26 +43,6 @@
 
                                     <label>Email</label>
                                     <input disabled class='input mb6' v-model='user.email' placeholder='Email' />
-                                </div>
-
-                                <div class='py6 col col--12 border--gray-light border-b'>
-                                    <span class='txt-m'>Account Security</span>
-                                </div>
-
-                                <div class='col col--12 py12'>
-                                    <label>Current Password</label>
-                                    <input type=password v-model='pw.current' class='input mb6' placeholder='Current Password' />
-                                </div>
-                                <div class='col col--5'>
-                                    <label>New Password</label>
-                                    <input type=password v-model='pw.newPass' class='input mb6' placeholder='New Password' />
-                                </div>
-                                <div class='col col--5'>
-                                    <label>Confirm New Password</label>
-                                    <input type=password v-model='pw.newConf' class='input mb6' placeholder='New Password' />
-                                </div>
-                                <div class='col col--2'>
-                                    <button @click='setPassword' style='margin-top: 22px;' class='btn'>Update</button>
                                 </div>
 
                                 <div class='py6 col col--12 border--gray-light border-b'>
@@ -76,6 +59,25 @@
                                     </div>
                                 </template>
                             </div>
+                        </template>
+                        <template v-else-if='mode === "security"'>
+                            <div class='grid grid--gut12 col col--12'>
+                                <div class='col col--12 py12'>
+                                    <label>Current Password</label>
+                                    <input type=password v-model='pw.current' class='input mb6' placeholder='Current Password' />
+                                </div>
+                                <div class='col col--5'>
+                                    <label>New Password</label>
+                                    <input type=password v-model='pw.newPass' class='input mb6' placeholder='New Password' />
+                                </div>
+                                <div class='col col--5'>
+                                    <label>Confirm New Password</label>
+                                    <input type=password v-model='pw.newConf' class='input mb6' placeholder='New Password' />
+                                </div>
+                                <div class='col col--2'>
+                                    <button @click='setPassword' style='margin-top: 22px;' class='btn btn--stroke round'>Update</button>
+                                </div>
+                            <div>
                         </template>
                         <template v-else-if='mode === "tokens"'>
                             <div class='grid grid--gut12 col col--12 pt12' style="max-height: 600px;">
@@ -102,6 +104,11 @@
                                 </div>
                             </div>
                         </template>
+                        <template v-else-if='mode === "token"'>
+                            Create a New Access Token
+                        </template>
+                    </div>
+                </template>
                     </div>
                 </template>
             </div>
@@ -137,6 +144,12 @@ export default {
                 'btn--white': this.mode === 'main' ? false : true
             };
         },
+        securitybtn: function() {
+            return {
+                'color-blue': this.mode === 'security' ? false : true,
+                'btn--white': this.mode === 'security' ? false : true
+            };
+        },
         tokensbtn: function() {
             return {
                 'color-blue': this.mode === 'tokens' ? false : true,
@@ -150,6 +163,10 @@ export default {
         },
         defaultJOSM: function() {
             return window.location.host + '/api';
+        },
+        token: function(token) {
+            this.mode = 'token';
+
         },
         createUrl: function() {
             fetch(`${window.location.protocol}//${window.location.host}/api/user/token`, {
@@ -185,8 +202,6 @@ export default {
                 this.error = 'New Passwords Must Match!';
                 return;
             }
-
-            console.error(JSON.stringify(this.pw));
 
             fetch(`${window.location.protocol}//${window.location.host}/api/user/reset`, {
                 method: 'POST',

--- a/migrations/v0.85.0-pre.sql
+++ b/migrations/v0.85.0-pre.sql
@@ -1,0 +1,23 @@
+-- tokens need a unique identifier so they can be deleted
+-- without having the original token
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+ALTER TABLE users_tokens
+    ADD COLUMN
+        id UUID UNIQUE NOT NULL;
+
+ALTER TABLE users_tokens
+    ALTER COLUMN name
+        SET NOT NULL;
+
+ALTER TABLE users_tokens
+    ALTER COLUMN name
+        SET NOT NULL;
+
+ALTER TABLE users_tokens
+    ALTER COLUMN uid
+        SET NOT NULL;
+
+ALTER TABLE users_tokens
+    ALTER COLUMN scope
+        SET NOT NULL;


### PR DESCRIPTION
### Context

Hecate has long had the ability to generate and track tokens in a generic way, however it has been tied primarily to session tokens. This goal of this PR is to add more generic handling of both session and user created tokens

### TODO

- [x] Don't ever return token value via the API except on initial create
- [x] Add API to list tokens
- [x] Add tests for listing tokens
- [x] Add user UI to list & manage tokens

cc/ @ingalls

