### PR TITLE
minor fixes to README for new directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cargo build
 ```bash
 echo "CREATE DATABASE hecate;" | psql -U postgres
 
-psql -U postgres -f src/schema.sql hecate
+psql -U postgres -f hecate/src/schema.sql hecate
 ```
 
 - This step will also create a database role called `hecate` and `hecate_read`. If
@@ -132,7 +132,7 @@ host replication postgres samenet trust
 - Install frontend dependencies
 
 ```
-cd web/
+cd hecate_ui/
 yarn install
 ```
 


### PR DESCRIPTION
### Context

Minor updates to the README reflecting the new directory structure:

 - UI folder is now called `hecate_ui` instead of `web`
 - Postgres schema is in `hecate/src/` instead or `src/`

cc/ @ingalls
